### PR TITLE
feat(backend): seed IBGE + endpoints de consulta com filtros e paginacao

### DIFF
--- a/backend/MapaTributário/src/MapaTributario.API/Application/Consulta/CodigoServicoNormalizer.cs
+++ b/backend/MapaTributário/src/MapaTributario.API/Application/Consulta/CodigoServicoNormalizer.cs
@@ -62,6 +62,32 @@ public static partial class CodigoServicoNormalizer
     }
 
     /// <summary>
+    /// Normaliza um codigo parcial ou completo para uso como prefixo de busca.
+    /// Aceita 2, 4 ou 6 digitos (com ou sem pontos).
+    /// Ex: "01" -> "01", "01.01" -> "0101", "01.01.00" -> "010100"
+    /// </summary>
+    public static string NormalizarPrefixo(string codigo)
+    {
+        if (string.IsNullOrWhiteSpace(codigo))
+        {
+            return string.Empty;
+        }
+
+        var limpo = codigo.Replace(".", "");
+        if (limpo.Length != 2 && limpo.Length != 4 && limpo.Length != 6)
+        {
+            return string.Empty;
+        }
+
+        if (!limpo.All(char.IsDigit))
+        {
+            return string.Empty;
+        }
+
+        return limpo;
+    }
+
+    /// <summary>
     /// Valida se o codigo esta em formato aceito (com ou sem pontos, 6 digitos).
     /// </summary>
     public static bool EhValido(string codigo)

--- a/backend/MapaTributário/src/MapaTributario.API/Application/Consulta/CodigoServicoNormalizer.cs
+++ b/backend/MapaTributário/src/MapaTributario.API/Application/Consulta/CodigoServicoNormalizer.cs
@@ -1,0 +1,86 @@
+using System.Text.RegularExpressions;
+
+namespace MapaTributario.API.Application.Consulta;
+
+public static partial class CodigoServicoNormalizer
+{
+    private static readonly Regex _formatoComPontos = new(@"^\d{2}\.\d{2}\.\d{2}$", RegexOptions.Compiled);
+    private static readonly Regex _formatoSemPontos = new(@"^\d{6}$", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Remove pontos do codigo de servico, retornando apenas digitos.
+    /// Ex: "01.02.00" -> "010200"
+    /// </summary>
+    public static string RemoverPontos(string codigo)
+    {
+        if (string.IsNullOrWhiteSpace(codigo))
+        {
+            return string.Empty;
+        }
+
+        return codigo.Replace(".", "");
+    }
+
+    /// <summary>
+    /// Formata codigo de servico com pontos no formato ii.ss.dd.
+    /// Ex: "010200" -> "01.02.00"
+    /// </summary>
+    public static string Formatar(string codigo)
+    {
+        if (string.IsNullOrWhiteSpace(codigo))
+        {
+            return string.Empty;
+        }
+
+        var limpo = codigo.Replace(".", "");
+        if (limpo.Length != 6)
+        {
+            return codigo;
+        }
+
+        return $"{limpo[..2]}.{limpo[2..4]}.{limpo[4..6]}";
+    }
+
+    /// <summary>
+    /// Normaliza o codigo para formato sem pontos (armazenamento).
+    /// Aceita "01.02.00" ou "010200".
+    /// </summary>
+    public static string Normalizar(string codigo)
+    {
+        if (string.IsNullOrWhiteSpace(codigo))
+        {
+            return string.Empty;
+        }
+
+        var limpo = codigo.Replace(".", "");
+        if (limpo.Length != 6 || !limpo.All(char.IsDigit))
+        {
+            return string.Empty;
+        }
+
+        return limpo;
+    }
+
+    /// <summary>
+    /// Valida se o codigo esta em formato aceito (com ou sem pontos, 6 digitos).
+    /// </summary>
+    public static bool EhValido(string codigo)
+    {
+        if (string.IsNullOrWhiteSpace(codigo))
+        {
+            return false;
+        }
+
+        if (_formatoComPontos.IsMatch(codigo))
+        {
+            return true;
+        }
+
+        if (_formatoSemPontos.IsMatch(codigo))
+        {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/backend/MapaTributário/src/MapaTributario.API/Application/Consulta/ConsultaService.cs
+++ b/backend/MapaTributário/src/MapaTributario.API/Application/Consulta/ConsultaService.cs
@@ -1,10 +1,11 @@
 using FluentResults;
 using MapaTributario.API.Application.Consulta.Contracts;
+using MapaTributario.API.Application.Errors;
 using MapaTributario.API.Domain.Interfaces;
 
 namespace MapaTributario.API.Application.Consulta;
 
-public class ConsultaService
+public class ConsultaService : IConsultaService
 {
     private readonly IEstadoRepository _estadoRepository;
     private readonly IMunicipioRepository _municipioRepository;
@@ -39,7 +40,8 @@ public class ConsultaService
         var estado = await _estadoRepository.GetBySiglaAsync(uf);
         if (estado is null)
         {
-            return Result.Fail<IReadOnlyList<MunicipioResponse>>($"UF '{uf}' não encontrada");
+            return Result.Fail<IReadOnlyList<MunicipioResponse>>(
+                new NotFoundError($"UF '{uf}' não encontrada"));
         }
 
         var municipios = await _municipioRepository.GetByUfAsync(uf);
@@ -61,17 +63,18 @@ public class ConsultaService
         var municipio = await _municipioRepository.GetByCodigoIbgeAsync(codigoIbge);
         if (municipio is null)
         {
-            return Result.Fail<PaginatedResponse<AliquotaResponse>>($"Município com código IBGE '{codigoIbge}' não encontrado");
+            return Result.Fail<PaginatedResponse<AliquotaResponse>>(
+                new NotFoundError($"Município com código IBGE '{codigoIbge}' não encontrado"));
         }
 
         string? codigoServicoNormalizado = null;
         if (!string.IsNullOrWhiteSpace(queryParams.CodigoServico))
         {
-            codigoServicoNormalizado = CodigoServicoNormalizer.Normalizar(queryParams.CodigoServico);
+            codigoServicoNormalizado = CodigoServicoNormalizer.NormalizarPrefixo(queryParams.CodigoServico);
             if (string.IsNullOrEmpty(codigoServicoNormalizado))
             {
                 return Result.Fail<PaginatedResponse<AliquotaResponse>>(
-                    $"Código de serviço '{queryParams.CodigoServico}' em formato inválido. Use ii.ss.dd ou iissdd");
+                    new ValidationError($"Código de serviço '{queryParams.CodigoServico}' em formato inválido. Use ii, ii.ss, ii.ss.dd ou equivalente sem pontos"));
             }
         }
 
@@ -108,21 +111,22 @@ public class ConsultaService
         var municipio = await _municipioRepository.GetByCodigoIbgeAsync(codigoIbge);
         if (municipio is null)
         {
-            return Result.Fail<AliquotaDetalheResponse>($"Município com código IBGE '{codigoIbge}' não encontrado");
+            return Result.Fail<AliquotaDetalheResponse>(
+                new NotFoundError($"Município com código IBGE '{codigoIbge}' não encontrado"));
         }
 
         var codigoNormalizado = CodigoServicoNormalizer.Normalizar(codigoServico);
         if (string.IsNullOrEmpty(codigoNormalizado))
         {
             return Result.Fail<AliquotaDetalheResponse>(
-                $"Código de serviço '{codigoServico}' em formato inválido. Use ii.ss.dd ou iissdd");
+                new ValidationError($"Código de serviço '{codigoServico}' em formato inválido. Use ii.ss.dd ou iissdd"));
         }
 
         var aliquota = await _aliquotaRepository.GetDetalheAsync(codigoIbge, codigoNormalizado);
         if (aliquota is null)
         {
             return Result.Fail<AliquotaDetalheResponse>(
-                $"Alíquota não encontrada para município '{codigoIbge}' e serviço '{codigoServico}'");
+                new NotFoundError($"Alíquota não encontrada para município '{codigoIbge}' e serviço '{codigoServico}'"));
         }
 
         return Result.Ok(new AliquotaDetalheResponse

--- a/backend/MapaTributário/src/MapaTributario.API/Application/Consulta/ConsultaService.cs
+++ b/backend/MapaTributário/src/MapaTributario.API/Application/Consulta/ConsultaService.cs
@@ -1,0 +1,140 @@
+using FluentResults;
+using MapaTributario.API.Application.Consulta.Contracts;
+using MapaTributario.API.Domain.Interfaces;
+
+namespace MapaTributario.API.Application.Consulta;
+
+public class ConsultaService
+{
+    private readonly IEstadoRepository _estadoRepository;
+    private readonly IMunicipioRepository _municipioRepository;
+    private readonly IAliquotaRepository _aliquotaRepository;
+
+    public ConsultaService(
+        IEstadoRepository estadoRepository,
+        IMunicipioRepository municipioRepository,
+        IAliquotaRepository aliquotaRepository)
+    {
+        _estadoRepository = estadoRepository;
+        _municipioRepository = municipioRepository;
+        _aliquotaRepository = aliquotaRepository;
+    }
+
+    public async Task<Result<IReadOnlyList<EstadoResponse>>> ListarEstadosAsync()
+    {
+        var estados = await _estadoRepository.GetAllAsync();
+
+        var response = estados.Select(e => new EstadoResponse
+        {
+            Sigla = e.Sigla,
+            Nome = e.Nome,
+            Regiao = e.Regiao
+        }).ToList();
+
+        return Result.Ok<IReadOnlyList<EstadoResponse>>(response);
+    }
+
+    public async Task<Result<IReadOnlyList<MunicipioResponse>>> ListarMunicipiosPorUfAsync(string uf)
+    {
+        var estado = await _estadoRepository.GetBySiglaAsync(uf);
+        if (estado is null)
+        {
+            return Result.Fail<IReadOnlyList<MunicipioResponse>>($"UF '{uf}' não encontrada");
+        }
+
+        var municipios = await _municipioRepository.GetByUfAsync(uf);
+
+        var response = municipios.Select(m => new MunicipioResponse
+        {
+            CodigoIbge = m.CodigoIbge,
+            Nome = m.Nome,
+            SiglaEstado = m.SiglaEstado
+        }).ToList();
+
+        return Result.Ok<IReadOnlyList<MunicipioResponse>>(response);
+    }
+
+    public async Task<Result<PaginatedResponse<AliquotaResponse>>> ListarAliquotasPorMunicipioAsync(
+        string codigoIbge,
+        AliquotaQueryParams queryParams)
+    {
+        var municipio = await _municipioRepository.GetByCodigoIbgeAsync(codigoIbge);
+        if (municipio is null)
+        {
+            return Result.Fail<PaginatedResponse<AliquotaResponse>>($"Município com código IBGE '{codigoIbge}' não encontrado");
+        }
+
+        string? codigoServicoNormalizado = null;
+        if (!string.IsNullOrWhiteSpace(queryParams.CodigoServico))
+        {
+            codigoServicoNormalizado = CodigoServicoNormalizer.Normalizar(queryParams.CodigoServico);
+            if (string.IsNullOrEmpty(codigoServicoNormalizado))
+            {
+                return Result.Fail<PaginatedResponse<AliquotaResponse>>(
+                    $"Código de serviço '{queryParams.CodigoServico}' em formato inválido. Use ii.ss.dd ou iissdd");
+            }
+        }
+
+        var (items, total) = await _aliquotaRepository.GetByMunicipioAsync(
+            codigoIbge,
+            queryParams.Pagina,
+            queryParams.TamanhoPagina,
+            codigoServicoNormalizado,
+            queryParams.Descricao,
+            queryParams.AliquotaMin,
+            queryParams.AliquotaMax,
+            queryParams.Competencia);
+
+        var responseItems = items.Select(a => new AliquotaResponse
+        {
+            CodigoServico = a.CodigoServico,
+            CodigoServicoFormatado = CodigoServicoNormalizer.Formatar(a.CodigoServico),
+            DescricaoServico = a.DescricaoServico,
+            ValorAliquota = a.ValorAliquota,
+            Competencia = a.Competencia
+        }).ToList();
+
+        return Result.Ok(PaginatedResponse<AliquotaResponse>.Create(
+            responseItems,
+            queryParams.Pagina,
+            queryParams.TamanhoPagina,
+            total));
+    }
+
+    public async Task<Result<AliquotaDetalheResponse>> ObterDetalheAliquotaAsync(
+        string codigoIbge,
+        string codigoServico)
+    {
+        var municipio = await _municipioRepository.GetByCodigoIbgeAsync(codigoIbge);
+        if (municipio is null)
+        {
+            return Result.Fail<AliquotaDetalheResponse>($"Município com código IBGE '{codigoIbge}' não encontrado");
+        }
+
+        var codigoNormalizado = CodigoServicoNormalizer.Normalizar(codigoServico);
+        if (string.IsNullOrEmpty(codigoNormalizado))
+        {
+            return Result.Fail<AliquotaDetalheResponse>(
+                $"Código de serviço '{codigoServico}' em formato inválido. Use ii.ss.dd ou iissdd");
+        }
+
+        var aliquota = await _aliquotaRepository.GetDetalheAsync(codigoIbge, codigoNormalizado);
+        if (aliquota is null)
+        {
+            return Result.Fail<AliquotaDetalheResponse>(
+                $"Alíquota não encontrada para município '{codigoIbge}' e serviço '{codigoServico}'");
+        }
+
+        return Result.Ok(new AliquotaDetalheResponse
+        {
+            CodigoMunicipio = aliquota.CodigoMunicipio,
+            NomeMunicipio = aliquota.NomeMunicipio,
+            CodigoServico = aliquota.CodigoServico,
+            CodigoServicoFormatado = CodigoServicoNormalizer.Formatar(aliquota.CodigoServico),
+            DescricaoServico = aliquota.DescricaoServico,
+            ValorAliquota = aliquota.ValorAliquota,
+            Competencia = aliquota.Competencia,
+            ColetadoEm = aliquota.ColetadoEm
+        });
+    }
+}

--- a/backend/MapaTributário/src/MapaTributario.API/Application/Consulta/Contracts/AliquotaDetalheResponse.cs
+++ b/backend/MapaTributário/src/MapaTributario.API/Application/Consulta/Contracts/AliquotaDetalheResponse.cs
@@ -1,0 +1,13 @@
+namespace MapaTributario.API.Application.Consulta.Contracts;
+
+public class AliquotaDetalheResponse
+{
+    public string CodigoMunicipio { get; set; } = null!;
+    public string NomeMunicipio { get; set; } = null!;
+    public string CodigoServico { get; set; } = null!;
+    public string CodigoServicoFormatado { get; set; } = null!;
+    public string DescricaoServico { get; set; } = null!;
+    public decimal ValorAliquota { get; set; }
+    public string Competencia { get; set; } = null!;
+    public DateTime ColetadoEm { get; set; }
+}

--- a/backend/MapaTributário/src/MapaTributario.API/Application/Consulta/Contracts/AliquotaQueryParams.cs
+++ b/backend/MapaTributário/src/MapaTributario.API/Application/Consulta/Contracts/AliquotaQueryParams.cs
@@ -1,0 +1,12 @@
+namespace MapaTributario.API.Application.Consulta.Contracts;
+
+public class AliquotaQueryParams
+{
+    public int Pagina { get; set; } = 1;
+    public int TamanhoPagina { get; set; } = 20;
+    public string? CodigoServico { get; set; }
+    public string? Descricao { get; set; }
+    public decimal? AliquotaMin { get; set; }
+    public decimal? AliquotaMax { get; set; }
+    public string? Competencia { get; set; }
+}

--- a/backend/MapaTributário/src/MapaTributario.API/Application/Consulta/Contracts/AliquotaResponse.cs
+++ b/backend/MapaTributário/src/MapaTributario.API/Application/Consulta/Contracts/AliquotaResponse.cs
@@ -1,0 +1,10 @@
+namespace MapaTributario.API.Application.Consulta.Contracts;
+
+public class AliquotaResponse
+{
+    public string CodigoServico { get; set; } = null!;
+    public string CodigoServicoFormatado { get; set; } = null!;
+    public string DescricaoServico { get; set; } = null!;
+    public decimal ValorAliquota { get; set; }
+    public string Competencia { get; set; } = null!;
+}

--- a/backend/MapaTributário/src/MapaTributario.API/Application/Consulta/Contracts/EstadoResponse.cs
+++ b/backend/MapaTributário/src/MapaTributario.API/Application/Consulta/Contracts/EstadoResponse.cs
@@ -1,0 +1,8 @@
+namespace MapaTributario.API.Application.Consulta.Contracts;
+
+public class EstadoResponse
+{
+    public string Sigla { get; set; } = null!;
+    public string Nome { get; set; } = null!;
+    public string Regiao { get; set; } = null!;
+}

--- a/backend/MapaTributário/src/MapaTributario.API/Application/Consulta/Contracts/MunicipioResponse.cs
+++ b/backend/MapaTributário/src/MapaTributario.API/Application/Consulta/Contracts/MunicipioResponse.cs
@@ -1,0 +1,8 @@
+namespace MapaTributario.API.Application.Consulta.Contracts;
+
+public class MunicipioResponse
+{
+    public string CodigoIbge { get; set; } = null!;
+    public string Nome { get; set; } = null!;
+    public string SiglaEstado { get; set; } = null!;
+}

--- a/backend/MapaTributário/src/MapaTributario.API/Application/Consulta/Contracts/PaginatedResponse.cs
+++ b/backend/MapaTributário/src/MapaTributario.API/Application/Consulta/Contracts/PaginatedResponse.cs
@@ -1,0 +1,26 @@
+namespace MapaTributario.API.Application.Consulta.Contracts;
+
+public class PaginatedResponse<T>
+{
+    public IReadOnlyList<T> Items { get; set; } = Array.Empty<T>();
+    public int Pagina { get; set; }
+    public int TamanhoPagina { get; set; }
+    public long TotalItens { get; set; }
+    public int TotalPaginas { get; set; }
+
+    public static PaginatedResponse<T> Create(
+        IReadOnlyList<T> items,
+        int pagina,
+        int tamanhoPagina,
+        long totalItens)
+    {
+        return new PaginatedResponse<T>
+        {
+            Items = items,
+            Pagina = pagina,
+            TamanhoPagina = tamanhoPagina,
+            TotalItens = totalItens,
+            TotalPaginas = tamanhoPagina > 0 ? (int)Math.Ceiling((double)totalItens / tamanhoPagina) : 0
+        };
+    }
+}

--- a/backend/MapaTributário/src/MapaTributario.API/Application/Consulta/IConsultaService.cs
+++ b/backend/MapaTributário/src/MapaTributario.API/Application/Consulta/IConsultaService.cs
@@ -1,0 +1,19 @@
+using FluentResults;
+using MapaTributario.API.Application.Consulta.Contracts;
+
+namespace MapaTributario.API.Application.Consulta;
+
+public interface IConsultaService
+{
+    Task<Result<IReadOnlyList<EstadoResponse>>> ListarEstadosAsync();
+
+    Task<Result<IReadOnlyList<MunicipioResponse>>> ListarMunicipiosPorUfAsync(string uf);
+
+    Task<Result<PaginatedResponse<AliquotaResponse>>> ListarAliquotasPorMunicipioAsync(
+        string codigoIbge,
+        AliquotaQueryParams queryParams);
+
+    Task<Result<AliquotaDetalheResponse>> ObterDetalheAliquotaAsync(
+        string codigoIbge,
+        string codigoServico);
+}

--- a/backend/MapaTributário/src/MapaTributario.API/Application/Errors/NotFoundError.cs
+++ b/backend/MapaTributário/src/MapaTributario.API/Application/Errors/NotFoundError.cs
@@ -1,0 +1,8 @@
+using FluentResults;
+
+namespace MapaTributario.API.Application.Errors;
+
+public class NotFoundError : Error
+{
+    public NotFoundError(string message) : base(message) { }
+}

--- a/backend/MapaTributário/src/MapaTributario.API/Application/Errors/ValidationError.cs
+++ b/backend/MapaTributário/src/MapaTributario.API/Application/Errors/ValidationError.cs
@@ -1,0 +1,8 @@
+using FluentResults;
+
+namespace MapaTributario.API.Application.Errors;
+
+public class ValidationError : Error
+{
+    public ValidationError(string message) : base(message) { }
+}

--- a/backend/MapaTributário/src/MapaTributario.API/Controllers/ConsultaController.cs
+++ b/backend/MapaTributário/src/MapaTributario.API/Controllers/ConsultaController.cs
@@ -1,0 +1,129 @@
+using FluentValidation;
+using MapaTributario.API.Application.Consulta;
+using MapaTributario.API.Application.Consulta.Contracts;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace MapaTributario.API.Controllers;
+
+/// <summary>
+/// Endpoints de consulta de estados, municipios e aliquotas.
+/// </summary>
+[ApiController]
+[Route("api/v1")]
+[Authorize]
+public class ConsultaController : ControllerBase
+{
+    private readonly ConsultaService _consultaService;
+
+    public ConsultaController(ConsultaService consultaService)
+    {
+        _consultaService = consultaService;
+    }
+
+    /// <summary>
+    /// Lista todos os 27 estados brasileiros ordenados por nome.
+    /// </summary>
+    /// <returns>Lista de estados com sigla, nome e regiao.</returns>
+    /// <response code="200">Lista de estados retornada com sucesso.</response>
+    /// <response code="401">Token JWT ausente ou invalido.</response>
+    [HttpGet("estados")]
+    [ProducesResponseType(typeof(IReadOnlyList<EstadoResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> ListarEstados()
+    {
+        var result = await _consultaService.ListarEstadosAsync();
+        return Ok(result.Value);
+    }
+
+    /// <summary>
+    /// Lista municipios de um estado pela sigla da UF.
+    /// </summary>
+    /// <param name="uf">Sigla da UF (ex: SP, RJ, MG).</param>
+    /// <returns>Lista de municipios do estado.</returns>
+    /// <response code="200">Lista de municipios retornada com sucesso.</response>
+    /// <response code="401">Token JWT ausente ou invalido.</response>
+    /// <response code="404">UF nao encontrada.</response>
+    [HttpGet("estados/{uf}/municipios")]
+    [ProducesResponseType(typeof(IReadOnlyList<MunicipioResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> ListarMunicipiosPorUf([FromRoute] string uf)
+    {
+        var result = await _consultaService.ListarMunicipiosPorUfAsync(uf);
+        if (result.IsFailed)
+        {
+            return NotFound(new { erro = result.Errors.First().Message });
+        }
+
+        return Ok(result.Value);
+    }
+
+    /// <summary>
+    /// Lista aliquotas de um municipio com paginacao e filtros.
+    /// </summary>
+    /// <param name="codigoIbge">Codigo IBGE do municipio (7 digitos).</param>
+    /// <param name="queryParams">Parametros de paginacao e filtros.</param>
+    /// <param name="validator">Validador injetado pelo container.</param>
+    /// <returns>Resposta paginada com aliquotas.</returns>
+    /// <response code="200">Lista paginada de aliquotas retornada com sucesso.</response>
+    /// <response code="400">Parametros de consulta invalidos.</response>
+    /// <response code="401">Token JWT ausente ou invalido.</response>
+    /// <response code="404">Municipio nao encontrado.</response>
+    [HttpGet("municipios/{codigoIbge}/aliquotas")]
+    [ProducesResponseType(typeof(PaginatedResponse<AliquotaResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> ListarAliquotasPorMunicipio(
+        [FromRoute] string codigoIbge,
+        [FromQuery] AliquotaQueryParams queryParams,
+        [FromServices] IValidator<AliquotaQueryParams> validator)
+    {
+        var validation = await validator.ValidateAsync(queryParams);
+        if (!validation.IsValid)
+        {
+            return BadRequest(new { erro = "Validação falhou", detalhes = validation.Errors.Select(e => e.ErrorMessage).ToArray() });
+        }
+
+        var result = await _consultaService.ListarAliquotasPorMunicipioAsync(codigoIbge, queryParams);
+        if (result.IsFailed)
+        {
+            var errorMessage = result.Errors.First().Message;
+            if (errorMessage.Contains("não encontrado"))
+            {
+                return NotFound(new { erro = errorMessage });
+            }
+
+            return BadRequest(new { erro = errorMessage });
+        }
+
+        return Ok(result.Value);
+    }
+
+    /// <summary>
+    /// Retorna detalhe de uma aliquota especifica para um municipio e servico.
+    /// </summary>
+    /// <param name="codigoIbge">Codigo IBGE do municipio (7 digitos).</param>
+    /// <param name="codigoServico">Codigo do servico (formato ii.ss.dd ou iissdd).</param>
+    /// <returns>Detalhe da aliquota.</returns>
+    /// <response code="200">Detalhe da aliquota retornado com sucesso.</response>
+    /// <response code="401">Token JWT ausente ou invalido.</response>
+    /// <response code="404">Municipio ou aliquota nao encontrada.</response>
+    [HttpGet("municipios/{codigoIbge}/aliquotas/{codigoServico}")]
+    [ProducesResponseType(typeof(AliquotaDetalheResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> ObterDetalheAliquota(
+        [FromRoute] string codigoIbge,
+        [FromRoute] string codigoServico)
+    {
+        var result = await _consultaService.ObterDetalheAliquotaAsync(codigoIbge, codigoServico);
+        if (result.IsFailed)
+        {
+            return NotFound(new { erro = result.Errors.First().Message });
+        }
+
+        return Ok(result.Value);
+    }
+}

--- a/backend/MapaTributário/src/MapaTributario.API/Controllers/ConsultaController.cs
+++ b/backend/MapaTributário/src/MapaTributario.API/Controllers/ConsultaController.cs
@@ -1,6 +1,7 @@
 using FluentValidation;
 using MapaTributario.API.Application.Consulta;
 using MapaTributario.API.Application.Consulta.Contracts;
+using MapaTributario.API.Application.Errors;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -14,9 +15,9 @@ namespace MapaTributario.API.Controllers;
 [Authorize]
 public class ConsultaController : ControllerBase
 {
-    private readonly ConsultaService _consultaService;
+    private readonly IConsultaService _consultaService;
 
-    public ConsultaController(ConsultaService consultaService)
+    public ConsultaController(IConsultaService consultaService)
     {
         _consultaService = consultaService;
     }
@@ -89,13 +90,12 @@ public class ConsultaController : ControllerBase
         var result = await _consultaService.ListarAliquotasPorMunicipioAsync(codigoIbge, queryParams);
         if (result.IsFailed)
         {
-            var errorMessage = result.Errors.First().Message;
-            if (errorMessage.Contains("não encontrado"))
+            if (result.Errors.OfType<NotFoundError>().Any())
             {
-                return NotFound(new { erro = errorMessage });
+                return NotFound(new { erro = result.Errors.First().Message });
             }
 
-            return BadRequest(new { erro = errorMessage });
+            return BadRequest(new { erro = result.Errors.First().Message });
         }
 
         return Ok(result.Value);

--- a/backend/MapaTributário/src/MapaTributario.API/Extensions/ConsultaServiceExtensions.cs
+++ b/backend/MapaTributário/src/MapaTributario.API/Extensions/ConsultaServiceExtensions.cs
@@ -1,3 +1,8 @@
+using MapaTributario.API.Application.Consulta;
+using MapaTributario.API.Domain.Interfaces;
+using MapaTributario.API.Infrastructure.Repository;
+using MapaTributario.API.Infrastructure.Seed;
+
 namespace MapaTributario.API.Extensions;
 
 public static class ConsultaServiceExtensions
@@ -6,7 +11,30 @@ public static class ConsultaServiceExtensions
         this IServiceCollection services,
         IConfiguration configuration)
     {
-        // Placeholder — será implementado pela PBI #4 (Backend Consulta)
+        // Repositories
+        services.AddSingleton<IEstadoRepository, EstadoRepository>();
+        services.AddSingleton<IMunicipioRepository, MunicipioRepository>();
+        services.AddSingleton<IServicoRepository, ServicoRepository>();
+        services.AddSingleton<IAliquotaRepository, AliquotaRepository>();
+
+        // Application services
+        services.AddScoped<ConsultaService>();
+
+        // Seed services
+        services.AddTransient<IbgeSeedService>();
+        services.AddTransient<ServicoSeedService>();
+
         return services;
+    }
+
+    public static async Task RunConsultaSeedsAsync(this WebApplication app)
+    {
+        using var scope = app.Services.CreateScope();
+
+        var ibgeSeed = scope.ServiceProvider.GetRequiredService<IbgeSeedService>();
+        await ibgeSeed.SeedAsync();
+
+        var servicoSeed = scope.ServiceProvider.GetRequiredService<ServicoSeedService>();
+        await servicoSeed.SeedAsync();
     }
 }

--- a/backend/MapaTributário/src/MapaTributario.API/Extensions/ConsultaServiceExtensions.cs
+++ b/backend/MapaTributário/src/MapaTributario.API/Extensions/ConsultaServiceExtensions.cs
@@ -18,7 +18,7 @@ public static class ConsultaServiceExtensions
         services.AddSingleton<IAliquotaRepository, AliquotaRepository>();
 
         // Application services
-        services.AddScoped<ConsultaService>();
+        services.AddScoped<IConsultaService, ConsultaService>();
 
         // Seed services
         services.AddTransient<IbgeSeedService>();

--- a/backend/MapaTributário/src/MapaTributario.API/Infrastructure/Repository/AliquotaRepository.cs
+++ b/backend/MapaTributário/src/MapaTributario.API/Infrastructure/Repository/AliquotaRepository.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using MapaTributario.API.Domain.Entities;
 using MapaTributario.API.Domain.Interfaces;
 using MongoDB.Driver;
@@ -48,7 +49,8 @@ public class AliquotaRepository : IAliquotaRepository
 
         if (!string.IsNullOrWhiteSpace(descricao))
         {
-            filter &= filterBuilder.Regex(a => a.DescricaoServico, new MongoDB.Bson.BsonRegularExpression(descricao, "i"));
+            var escapedDescricao = Regex.Escape(descricao);
+            filter &= filterBuilder.Regex(a => a.DescricaoServico, new MongoDB.Bson.BsonRegularExpression(escapedDescricao, "i"));
         }
 
         if (aliquotaMin.HasValue)

--- a/backend/MapaTributário/src/MapaTributario.API/Infrastructure/Repository/AliquotaRepository.cs
+++ b/backend/MapaTributário/src/MapaTributario.API/Infrastructure/Repository/AliquotaRepository.cs
@@ -44,7 +44,15 @@ public class AliquotaRepository : IAliquotaRepository
 
         if (!string.IsNullOrWhiteSpace(codigoServico))
         {
-            filter &= filterBuilder.Eq(a => a.CodigoServico, codigoServico);
+            if (codigoServico.Length < 6)
+            {
+                var escapedPrefix = Regex.Escape(codigoServico);
+                filter &= filterBuilder.Regex(a => a.CodigoServico, new MongoDB.Bson.BsonRegularExpression($"^{escapedPrefix}"));
+            }
+            else
+            {
+                filter &= filterBuilder.Eq(a => a.CodigoServico, codigoServico);
+            }
         }
 
         if (!string.IsNullOrWhiteSpace(descricao))

--- a/backend/MapaTributário/src/MapaTributario.API/Infrastructure/Repository/AliquotaRepository.cs
+++ b/backend/MapaTributário/src/MapaTributario.API/Infrastructure/Repository/AliquotaRepository.cs
@@ -1,0 +1,120 @@
+using MapaTributario.API.Domain.Entities;
+using MapaTributario.API.Domain.Interfaces;
+using MongoDB.Driver;
+
+namespace MapaTributario.API.Infrastructure.Repository;
+
+public class AliquotaRepository : IAliquotaRepository
+{
+    private readonly IMongoCollection<Aliquota> _aliquotas;
+
+    public AliquotaRepository(IMongoDatabase database)
+    {
+        _aliquotas = database.GetCollection<Aliquota>("aliquotas");
+
+        var municipioIndex = Builders<Aliquota>.IndexKeys.Ascending(a => a.CodigoMunicipio);
+        _aliquotas.Indexes.CreateOne(new CreateIndexModel<Aliquota>(municipioIndex));
+
+        var compostoIndex = Builders<Aliquota>.IndexKeys
+            .Ascending(a => a.CodigoMunicipio)
+            .Ascending(a => a.CodigoServico);
+        _aliquotas.Indexes.CreateOne(
+            new CreateIndexModel<Aliquota>(compostoIndex, new CreateIndexOptions { Unique = true }));
+
+        var competenciaIndex = Builders<Aliquota>.IndexKeys
+            .Ascending(a => a.CodigoMunicipio)
+            .Ascending(a => a.CodigoServico)
+            .Ascending(a => a.Competencia);
+        _aliquotas.Indexes.CreateOne(new CreateIndexModel<Aliquota>(competenciaIndex));
+    }
+
+    public async Task<(IReadOnlyList<Aliquota> Items, long Total)> GetByMunicipioAsync(
+        string codigoIbge,
+        int pagina,
+        int tamanhoPagina,
+        string? codigoServico = null,
+        string? descricao = null,
+        decimal? aliquotaMin = null,
+        decimal? aliquotaMax = null,
+        string? competencia = null)
+    {
+        var filterBuilder = Builders<Aliquota>.Filter;
+        var filter = filterBuilder.Eq(a => a.CodigoMunicipio, codigoIbge);
+
+        if (!string.IsNullOrWhiteSpace(codigoServico))
+        {
+            filter &= filterBuilder.Eq(a => a.CodigoServico, codigoServico);
+        }
+
+        if (!string.IsNullOrWhiteSpace(descricao))
+        {
+            filter &= filterBuilder.Regex(a => a.DescricaoServico, new MongoDB.Bson.BsonRegularExpression(descricao, "i"));
+        }
+
+        if (aliquotaMin.HasValue)
+        {
+            filter &= filterBuilder.Gte(a => a.ValorAliquota, aliquotaMin.Value);
+        }
+
+        if (aliquotaMax.HasValue)
+        {
+            filter &= filterBuilder.Lte(a => a.ValorAliquota, aliquotaMax.Value);
+        }
+
+        if (!string.IsNullOrWhiteSpace(competencia))
+        {
+            filter &= filterBuilder.Eq(a => a.Competencia, competencia);
+        }
+
+        var total = await _aliquotas.CountDocumentsAsync(filter);
+
+        var items = await _aliquotas
+            .Find(filter)
+            .SortBy(a => a.CodigoServico)
+            .Skip((pagina - 1) * tamanhoPagina)
+            .Limit(tamanhoPagina)
+            .ToListAsync();
+
+        return (items, total);
+    }
+
+    public async Task<Aliquota?> GetDetalheAsync(string codigoIbge, string codigoServico)
+    {
+        return await _aliquotas
+            .Find(a => a.CodigoMunicipio == codigoIbge && a.CodigoServico == codigoServico)
+            .FirstOrDefaultAsync();
+    }
+
+    public async Task UpsertAsync(Aliquota aliquota)
+    {
+        var filter = Builders<Aliquota>.Filter.Eq(a => a.CodigoMunicipio, aliquota.CodigoMunicipio)
+            & Builders<Aliquota>.Filter.Eq(a => a.CodigoServico, aliquota.CodigoServico);
+
+        var existing = await _aliquotas.Find(filter).FirstOrDefaultAsync();
+        if (existing is null)
+        {
+            await _aliquotas.InsertOneAsync(aliquota);
+        }
+        else
+        {
+            var update = Builders<Aliquota>.Update
+                .Set(a => a.ValorAliquota, aliquota.ValorAliquota)
+                .Set(a => a.Competencia, aliquota.Competencia)
+                .Set(a => a.ColetadoEm, aliquota.ColetadoEm)
+                .Set(a => a.DescricaoServico, aliquota.DescricaoServico)
+                .Set(a => a.CodigoServicoFormatado, aliquota.CodigoServicoFormatado)
+                .Set(a => a.NomeMunicipio, aliquota.NomeMunicipio);
+
+            await _aliquotas.UpdateOneAsync(filter, update);
+        }
+    }
+
+    public async Task<bool> ExistsAsync(string codigoMunicipio, string codigoServico, string competencia)
+    {
+        var filter = Builders<Aliquota>.Filter.Eq(a => a.CodigoMunicipio, codigoMunicipio)
+            & Builders<Aliquota>.Filter.Eq(a => a.CodigoServico, codigoServico)
+            & Builders<Aliquota>.Filter.Eq(a => a.Competencia, competencia);
+
+        return await _aliquotas.CountDocumentsAsync(filter) > 0;
+    }
+}

--- a/backend/MapaTributário/src/MapaTributario.API/Infrastructure/Repository/EstadoRepository.cs
+++ b/backend/MapaTributário/src/MapaTributario.API/Infrastructure/Repository/EstadoRepository.cs
@@ -1,0 +1,48 @@
+using MapaTributario.API.Domain.Entities;
+using MapaTributario.API.Domain.Interfaces;
+using MongoDB.Driver;
+
+namespace MapaTributario.API.Infrastructure.Repository;
+
+public class EstadoRepository : IEstadoRepository
+{
+    private readonly IMongoCollection<Estado> _estados;
+
+    public EstadoRepository(IMongoDatabase database)
+    {
+        _estados = database.GetCollection<Estado>("estados");
+
+        var indexKeys = Builders<Estado>.IndexKeys.Ascending(e => e.Sigla);
+        var indexOptions = new CreateIndexOptions { Unique = true };
+        _estados.Indexes.CreateOne(new CreateIndexModel<Estado>(indexKeys, indexOptions));
+    }
+
+    public async Task<IReadOnlyList<Estado>> GetAllAsync()
+    {
+        return await _estados
+            .Find(FilterDefinition<Estado>.Empty)
+            .SortBy(e => e.Nome)
+            .ToListAsync();
+    }
+
+    public async Task<Estado?> GetBySiglaAsync(string sigla)
+    {
+        return await _estados
+            .Find(e => e.Sigla == sigla.ToUpperInvariant())
+            .FirstOrDefaultAsync();
+    }
+
+    public async Task<long> CountAsync()
+    {
+        return await _estados.CountDocumentsAsync(FilterDefinition<Estado>.Empty);
+    }
+
+    public async Task InsertManyAsync(IEnumerable<Estado> estados)
+    {
+        var list = estados.ToList();
+        if (list.Count > 0)
+        {
+            await _estados.InsertManyAsync(list);
+        }
+    }
+}

--- a/backend/MapaTributário/src/MapaTributario.API/Infrastructure/Repository/MunicipioRepository.cs
+++ b/backend/MapaTributário/src/MapaTributario.API/Infrastructure/Repository/MunicipioRepository.cs
@@ -1,0 +1,51 @@
+using MapaTributario.API.Domain.Entities;
+using MapaTributario.API.Domain.Interfaces;
+using MongoDB.Driver;
+
+namespace MapaTributario.API.Infrastructure.Repository;
+
+public class MunicipioRepository : IMunicipioRepository
+{
+    private readonly IMongoCollection<Municipio> _municipios;
+
+    public MunicipioRepository(IMongoDatabase database)
+    {
+        _municipios = database.GetCollection<Municipio>("municipios");
+
+        var codigoIndex = Builders<Municipio>.IndexKeys.Ascending(m => m.CodigoIbge);
+        _municipios.Indexes.CreateOne(
+            new CreateIndexModel<Municipio>(codigoIndex, new CreateIndexOptions { Unique = true }));
+
+        var ufIndex = Builders<Municipio>.IndexKeys.Ascending(m => m.SiglaEstado);
+        _municipios.Indexes.CreateOne(new CreateIndexModel<Municipio>(ufIndex));
+    }
+
+    public async Task<IReadOnlyList<Municipio>> GetByUfAsync(string siglaEstado)
+    {
+        return await _municipios
+            .Find(m => m.SiglaEstado == siglaEstado.ToUpperInvariant())
+            .SortBy(m => m.Nome)
+            .ToListAsync();
+    }
+
+    public async Task<Municipio?> GetByCodigoIbgeAsync(string codigoIbge)
+    {
+        return await _municipios
+            .Find(m => m.CodigoIbge == codigoIbge)
+            .FirstOrDefaultAsync();
+    }
+
+    public async Task<long> CountAsync()
+    {
+        return await _municipios.CountDocumentsAsync(FilterDefinition<Municipio>.Empty);
+    }
+
+    public async Task InsertManyAsync(IEnumerable<Municipio> municipios)
+    {
+        var list = municipios.ToList();
+        if (list.Count > 0)
+        {
+            await _municipios.InsertManyAsync(list);
+        }
+    }
+}

--- a/backend/MapaTributário/src/MapaTributario.API/Infrastructure/Repository/ServicoRepository.cs
+++ b/backend/MapaTributário/src/MapaTributario.API/Infrastructure/Repository/ServicoRepository.cs
@@ -1,0 +1,48 @@
+using MapaTributario.API.Domain.Entities;
+using MapaTributario.API.Domain.Interfaces;
+using MongoDB.Driver;
+
+namespace MapaTributario.API.Infrastructure.Repository;
+
+public class ServicoRepository : IServicoRepository
+{
+    private readonly IMongoCollection<Servico> _servicos;
+
+    public ServicoRepository(IMongoDatabase database)
+    {
+        _servicos = database.GetCollection<Servico>("servicos");
+
+        var codigoIndex = Builders<Servico>.IndexKeys.Ascending(s => s.CodigoTribNac);
+        _servicos.Indexes.CreateOne(
+            new CreateIndexModel<Servico>(codigoIndex, new CreateIndexOptions { Unique = true }));
+    }
+
+    public async Task<IReadOnlyList<Servico>> GetAllAsync()
+    {
+        return await _servicos
+            .Find(FilterDefinition<Servico>.Empty)
+            .SortBy(s => s.CodigoTribNac)
+            .ToListAsync();
+    }
+
+    public async Task<Servico?> GetByCodigoAsync(string codigoTribNac)
+    {
+        return await _servicos
+            .Find(s => s.CodigoTribNac == codigoTribNac)
+            .FirstOrDefaultAsync();
+    }
+
+    public async Task<long> CountAsync()
+    {
+        return await _servicos.CountDocumentsAsync(FilterDefinition<Servico>.Empty);
+    }
+
+    public async Task InsertManyAsync(IEnumerable<Servico> servicos)
+    {
+        var list = servicos.ToList();
+        if (list.Count > 0)
+        {
+            await _servicos.InsertManyAsync(list);
+        }
+    }
+}

--- a/backend/MapaTributário/src/MapaTributario.API/Infrastructure/Seed/IbgeSeedService.cs
+++ b/backend/MapaTributário/src/MapaTributario.API/Infrastructure/Seed/IbgeSeedService.cs
@@ -1,0 +1,133 @@
+using System.Text.Json;
+using MapaTributario.API.Domain.Entities;
+using MapaTributario.API.Domain.Interfaces;
+
+namespace MapaTributario.API.Infrastructure.Seed;
+
+public class IbgeSeedService
+{
+    private readonly IEstadoRepository _estadoRepository;
+    private readonly IMunicipioRepository _municipioRepository;
+    private readonly ILogger<IbgeSeedService> _logger;
+
+    private static readonly Dictionary<string, string> _nomeEstado = new()
+    {
+        ["AC"] = "Acre",
+        ["AL"] = "Alagoas",
+        ["AM"] = "Amazonas",
+        ["AP"] = "Amapá",
+        ["BA"] = "Bahia",
+        ["CE"] = "Ceará",
+        ["DF"] = "Distrito Federal",
+        ["ES"] = "Espírito Santo",
+        ["GO"] = "Goiás",
+        ["MA"] = "Maranhão",
+        ["MG"] = "Minas Gerais",
+        ["MS"] = "Mato Grosso do Sul",
+        ["MT"] = "Mato Grosso",
+        ["PA"] = "Pará",
+        ["PB"] = "Paraíba",
+        ["PE"] = "Pernambuco",
+        ["PI"] = "Piauí",
+        ["PR"] = "Paraná",
+        ["RJ"] = "Rio de Janeiro",
+        ["RN"] = "Rio Grande do Norte",
+        ["RO"] = "Rondônia",
+        ["RR"] = "Roraima",
+        ["RS"] = "Rio Grande do Sul",
+        ["SC"] = "Santa Catarina",
+        ["SE"] = "Sergipe",
+        ["SP"] = "São Paulo",
+        ["TO"] = "Tocantins"
+    };
+
+    private static readonly Dictionary<string, string> _regiaoByUf = new()
+    {
+        ["AC"] = "N", ["AM"] = "N", ["AP"] = "N", ["PA"] = "N", ["RO"] = "N", ["RR"] = "N", ["TO"] = "N",
+        ["AL"] = "NE", ["BA"] = "NE", ["CE"] = "NE", ["MA"] = "NE", ["PB"] = "NE",
+        ["PE"] = "NE", ["PI"] = "NE", ["RN"] = "NE", ["SE"] = "NE",
+        ["DF"] = "CO", ["GO"] = "CO", ["MS"] = "CO", ["MT"] = "CO",
+        ["ES"] = "SE", ["MG"] = "SE", ["RJ"] = "SE", ["SP"] = "SE",
+        ["PR"] = "S", ["RS"] = "S", ["SC"] = "S"
+    };
+
+    public IbgeSeedService(
+        IEstadoRepository estadoRepository,
+        IMunicipioRepository municipioRepository,
+        ILogger<IbgeSeedService> logger)
+    {
+        _estadoRepository = estadoRepository;
+        _municipioRepository = municipioRepository;
+        _logger = logger;
+    }
+
+    public async Task SeedAsync()
+    {
+        await SeedEstadosAsync();
+        await SeedMunicipiosAsync();
+    }
+
+    private async Task SeedEstadosAsync()
+    {
+        var count = await _estadoRepository.CountAsync();
+        if (count > 0)
+        {
+            _logger.LogInformation("Estados já existem ({Count} registros). Seed ignorado.", count);
+            return;
+        }
+
+        var estados = _nomeEstado.Select(kv =>
+            Estado.Create(kv.Key, kv.Value, _regiaoByUf[kv.Key])).ToList();
+
+        await _estadoRepository.InsertManyAsync(estados);
+        _logger.LogInformation("Seed de estados concluído: {Count} estados inseridos.", estados.Count);
+    }
+
+    private async Task SeedMunicipiosAsync()
+    {
+        var count = await _municipioRepository.CountAsync();
+        if (count > 0)
+        {
+            _logger.LogInformation("Municípios já existem ({Count} registros). Seed ignorado.", count);
+            return;
+        }
+
+        var jsonPath = Path.Combine(AppContext.BaseDirectory, "context", "municipios.json");
+        if (!File.Exists(jsonPath))
+        {
+            _logger.LogWarning("Arquivo municipios.json não encontrado em {Path}. Seed de municípios ignorado.", jsonPath);
+            return;
+        }
+
+        var json = await File.ReadAllTextAsync(jsonPath);
+        var data = JsonSerializer.Deserialize<MunicipioJsonRoot>(json, new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        });
+
+        if (data?.Data is null || data.Data.Count == 0)
+        {
+            _logger.LogWarning("Arquivo municipios.json está vazio ou sem dados.");
+            return;
+        }
+
+        var municipios = data.Data.Select(m =>
+            Municipio.Create(m.Codigo.ToString(), m.Nome, m.Uf)).ToList();
+
+        await _municipioRepository.InsertManyAsync(municipios);
+        _logger.LogInformation("Seed de municípios concluído: {Count} municípios inseridos.", municipios.Count);
+    }
+
+    private sealed class MunicipioJsonRoot
+    {
+        public List<MunicipioJsonItem> Data { get; set; } = new();
+    }
+
+    private sealed class MunicipioJsonItem
+    {
+        public int Id { get; set; }
+        public int Codigo { get; set; }
+        public string Nome { get; set; } = null!;
+        public string Uf { get; set; } = null!;
+    }
+}

--- a/backend/MapaTributário/src/MapaTributario.API/Infrastructure/Seed/ServicoSeedService.cs
+++ b/backend/MapaTributário/src/MapaTributario.API/Infrastructure/Seed/ServicoSeedService.cs
@@ -34,11 +34,25 @@ public class ServicoSeedService
     {
         var servicos = new List<Servico>();
 
-        // LC 116/2003 - 40 itens principais com subitens comuns
-        // Formato código tributação nacional: ii.ss.dd (item.subitem.desdobramento)
-
-        AddServicos(servicos, "01", "Serviços de informática e congêneres", new[]
+        foreach (var (item, subitens) in Lc116Data)
         {
+            foreach (var (subitem, descricao) in subitens)
+            {
+                var codigo = $"{item}.{subitem}.00";
+                servicos.Add(Servico.Create(codigo, descricao, item, subitem, "00"));
+            }
+        }
+
+        return servicos;
+    }
+
+    /// <summary>
+    /// Tabela completa da LC 116/2003 — 40 itens com subitens.
+    /// Formato: (item, [(subitem, descricao), ...])
+    /// </summary>
+    private static readonly (string Item, (string Sub, string Desc)[] Subitens)[] Lc116Data =
+    [
+        ("01", [
             ("01", "Análise e desenvolvimento de sistemas"),
             ("02", "Programação"),
             ("03", "Processamento, armazenamento ou hospedagem de dados"),
@@ -47,24 +61,16 @@ public class ServicoSeedService
             ("06", "Assessoria e consultoria em informática"),
             ("07", "Suporte técnico em informática"),
             ("08", "Planejamento, confecção, manutenção de páginas eletrônicas"),
-            ("09", "Disponibilização de conteúdos de áudio, vídeo, imagem e texto")
-        });
-
-        AddServicos(servicos, "02", "Serviços de pesquisas e desenvolvimento de qualquer natureza", new[]
-        {
-            ("01", "Serviços de pesquisas e desenvolvimento de qualquer natureza")
-        });
-
-        AddServicos(servicos, "03", "Serviços prestados mediante locação, cessão de direito de uso e congêneres", new[]
-        {
+            ("09", "Disponibilização de conteúdos de áudio, vídeo, imagem e texto"),
+        ]),
+        ("02", [("01", "Serviços de pesquisas e desenvolvimento de qualquer natureza")]),
+        ("03", [
             ("02", "Cessão de direito de uso de marcas e sinais de propaganda"),
             ("03", "Exploração de salões de festas e outros espaços"),
             ("04", "Locação, sublocação, arrendamento de bens"),
-            ("05", "Cessão de andaimes, palcos e estruturas de uso temporário")
-        });
-
-        AddServicos(servicos, "04", "Serviços de saúde, assistência médica e congêneres", new[]
-        {
+            ("05", "Cessão de andaimes, palcos e estruturas de uso temporário"),
+        ]),
+        ("04", [
             ("01", "Medicina e biomedicina"),
             ("02", "Análises clínicas, patologia e eletricidade médica"),
             ("03", "Hospitais, clínicas, laboratórios, sanatórios e congêneres"),
@@ -87,11 +93,9 @@ public class ServicoSeedService
             ("20", "Planos de medicina de grupo ou individual"),
             ("21", "Outros planos de saúde"),
             ("22", "Outros serviços de saúde"),
-            ("23", "Serviços de saúde prestados em regime de home care")
-        });
-
-        AddServicos(servicos, "05", "Serviços de medicina e assistência veterinária e congêneres", new[]
-        {
+            ("23", "Serviços de saúde prestados em regime de home care"),
+        ]),
+        ("05", [
             ("01", "Medicina veterinária e zootecnia"),
             ("02", "Hospitais, clínicas e ambulatórios veterinários"),
             ("03", "Laboratórios de análise na área veterinária"),
@@ -100,21 +104,17 @@ public class ServicoSeedService
             ("06", "Tosa, banho e embelezamento de animais"),
             ("07", "Guarda, tratamento, amestramento e adestramento"),
             ("08", "Ensino e treinamento de animais"),
-            ("09", "Planos de atendimento e assistência veterinária")
-        });
-
-        AddServicos(servicos, "06", "Serviços de cuidados pessoais, estética, atividades físicas e congêneres", new[]
-        {
+            ("09", "Planos de atendimento e assistência veterinária"),
+        ]),
+        ("06", [
             ("01", "Barbearia, cabeleireiros e congêneres"),
             ("02", "Esteticistas, tratamento de pele e congêneres"),
             ("03", "Banhos, duchas, sauna e massagens"),
             ("04", "Ginástica, dança, esportes e congêneres"),
             ("05", "Centros de emagrecimento, spa e congêneres"),
-            ("06", "Aplicação de tatuagens, piercings e congêneres")
-        });
-
-        AddServicos(servicos, "07", "Serviços relativos a engenharia, arquitetura, geologia, urbanismo, construção civil e congêneres", new[]
-        {
+            ("06", "Aplicação de tatuagens, piercings e congêneres"),
+        ]),
+        ("07", [
             ("01", "Engenharia, agronomia, agrimensura e congêneres"),
             ("02", "Execução de obras de construção civil e hidráulica"),
             ("03", "Elaboração de planos diretores e projetos"),
@@ -136,24 +136,18 @@ public class ServicoSeedService
             ("19", "Pesquisa, perfuração, cimentação e perfilagem de poços"),
             ("20", "Nucleação e bombardeamento de nuvens"),
             ("21", "Serviços de topografia"),
-            ("22", "Serviços de geologia e geotécnica")
-        });
-
-        AddServicos(servicos, "08", "Serviços de educação, ensino, orientação pedagógica e educacional, instrução, treinamento e avaliação pessoal", new[]
-        {
+            ("22", "Serviços de geologia e geotécnica"),
+        ]),
+        ("08", [
             ("01", "Ensino regular pré-escolar, fundamental, médio e superior"),
-            ("02", "Instrução, treinamento, orientação pedagógica, avaliação")
-        });
-
-        AddServicos(servicos, "09", "Serviços relativos a hospedagem, turismo, viagens e congêneres", new[]
-        {
+            ("02", "Instrução, treinamento, orientação pedagógica, avaliação"),
+        ]),
+        ("09", [
             ("01", "Hospedagem em hotéis, apart-hotéis e congêneres"),
             ("02", "Agenciamento, organização e promoção de turismo"),
-            ("03", "Guias de turismo")
-        });
-
-        AddServicos(servicos, "10", "Serviços de intermediação e congêneres", new[]
-        {
+            ("03", "Guias de turismo"),
+        ]),
+        ("10", [
             ("01", "Agenciamento, corretagem de câmbio, seguros e congêneres"),
             ("02", "Agenciamento, corretagem de títulos em geral"),
             ("03", "Agenciamento, corretagem de contratos de arrendamento mercantil"),
@@ -163,19 +157,15 @@ public class ServicoSeedService
             ("07", "Agenciamento de notícias"),
             ("08", "Agenciamento de publicidade e propaganda"),
             ("09", "Representação de qualquer natureza"),
-            ("10", "Distribuição de bens de terceiros")
-        });
-
-        AddServicos(servicos, "11", "Serviços de guarda, estacionamento, armazenamento, vigilância e congêneres", new[]
-        {
+            ("10", "Distribuição de bens de terceiros"),
+        ]),
+        ("11", [
             ("01", "Guarda e estacionamento de veículos"),
             ("02", "Vigilância, segurança ou monitoramento"),
             ("03", "Escolta, inclusive de veículos e cargas"),
-            ("04", "Armazenamento, depósito, carga e descarga")
-        });
-
-        AddServicos(servicos, "12", "Serviços de diversões, lazer, entretenimento e congêneres", new[]
-        {
+            ("04", "Armazenamento, depósito, carga e descarga"),
+        ]),
+        ("12", [
             ("01", "Espetáculos teatrais"),
             ("02", "Exibições cinematográficas"),
             ("03", "Espetáculos circenses"),
@@ -192,20 +182,16 @@ public class ServicoSeedService
             ("14", "Fornecimento de música para ambientes"),
             ("15", "Desfiles de blocos carnavalescos"),
             ("16", "Exibição de filmes e espetáculos"),
-            ("17", "Recreação e animação")
-        });
-
-        AddServicos(servicos, "13", "Serviços relativos a fonografia, fotografia, cinematografia e reprografia", new[]
-        {
+            ("17", "Recreação e animação"),
+        ]),
+        ("13", [
             ("01", "Fonografia"),
             ("02", "Fotografia e cinematografia"),
             ("03", "Reprografia, microfilmagem e digitalização"),
             ("04", "Composição gráfica e fotocomposição"),
-            ("05", "Composição gráfica, inclusive confecção de impressos gráficos")
-        });
-
-        AddServicos(servicos, "14", "Serviços relativos a bens de terceiros", new[]
-        {
+            ("05", "Composição gráfica, inclusive confecção de impressos gráficos"),
+        ]),
+        ("14", [
             ("01", "Lubrificação, limpeza, lustração, revisão de máquinas"),
             ("02", "Assistência técnica"),
             ("03", "Recondicionamento de motores"),
@@ -219,11 +205,9 @@ public class ServicoSeedService
             ("11", "Tapeçaria e reforma de estofamentos"),
             ("12", "Funilaria e lanternagem"),
             ("13", "Carpintaria e serralheria"),
-            ("14", "Guincho intramunicipal, guindaste e içamento")
-        });
-
-        AddServicos(servicos, "15", "Serviços relacionados ao setor bancário ou financeiro", new[]
-        {
+            ("14", "Guincho intramunicipal, guindaste e içamento"),
+        ]),
+        ("15", [
             ("01", "Administração de fundos, consórcio e cartão de crédito"),
             ("02", "Abertura de contas"),
             ("03", "Locação e manutenção de cofres"),
@@ -241,17 +225,13 @@ public class ServicoSeedService
             ("15", "Compensação de cheques e títulos"),
             ("16", "Emissão, fornecimento de documentos bancários"),
             ("17", "Concessão, revisão, retificação de empréstimos"),
-            ("18", "Emissão, concessão, alteração de cartão de crédito")
-        });
-
-        AddServicos(servicos, "16", "Serviços de transporte de natureza municipal", new[]
-        {
+            ("18", "Emissão, concessão, alteração de cartão de crédito"),
+        ]),
+        ("16", [
             ("01", "Serviços de transporte coletivo municipal rodoviário"),
-            ("02", "Outros serviços de transporte de natureza municipal")
-        });
-
-        AddServicos(servicos, "17", "Serviços de apoio técnico, administrativo, jurídico, contábil, comercial e congêneres", new[]
-        {
+            ("02", "Outros serviços de transporte de natureza municipal"),
+        ]),
+        ("17", [
             ("01", "Assessoria ou consultoria de qualquer natureza"),
             ("02", "Datilografia, digitação, estenografia e congêneres"),
             ("03", "Planejamento, coordenação, programação e organização técnica"),
@@ -276,145 +256,40 @@ public class ServicoSeedService
             ("22", "Assessoria, análise, avaliação e informações de risco"),
             ("23", "Apresentação de palestras, conferências e seminários"),
             ("24", "Inserção de textos, desenhos e outros materiais de propaganda"),
-            ("25", "Serviços de investigações particulares, detetives e congêneres")
-        });
-
-        AddServicos(servicos, "18", "Serviços de regulação de sinistros vinculados a contratos de seguros", new[]
-        {
-            ("01", "Serviços de regulação de sinistros")
-        });
-
-        AddServicos(servicos, "19", "Serviços de distribuição e venda de bilhetes e demais produtos de loteria", new[]
-        {
-            ("01", "Serviços de distribuição e venda de bilhetes de loteria")
-        });
-
-        AddServicos(servicos, "20", "Serviços portuários, aeroportuários, ferroportuários, de terminais rodoviários, ferroviários e metroviários", new[]
-        {
+            ("25", "Serviços de investigações particulares, detetives e congêneres"),
+        ]),
+        ("18", [("01", "Serviços de regulação de sinistros")]),
+        ("19", [("01", "Serviços de distribuição e venda de bilhetes de loteria")]),
+        ("20", [
             ("01", "Serviços portuários e ferroportuários"),
             ("02", "Serviços aeroportuários"),
-            ("03", "Serviços de terminais rodoviários, ferroviários e metroviários")
-        });
-
-        AddServicos(servicos, "21", "Serviços de registros públicos, cartorários e notariais", new[]
-        {
-            ("01", "Serviços de registros públicos, cartorários e notariais")
-        });
-
-        AddServicos(servicos, "22", "Serviços de exploração de rodovia", new[]
-        {
-            ("01", "Serviços de exploração de rodovia mediante cobrança de pedágio")
-        });
-
-        AddServicos(servicos, "23", "Serviços de programação e comunicação visual, desenho industrial e congêneres", new[]
-        {
-            ("01", "Serviços de programação e comunicação visual, desenho industrial")
-        });
-
-        AddServicos(servicos, "24", "Serviços de chaveiros, confecção de carimbos, placas, sinalização visual, banners, adesivos e congêneres", new[]
-        {
-            ("01", "Serviços de chaveiros, confecção de carimbos, placas, banners")
-        });
-
-        AddServicos(servicos, "25", "Serviços funerários", new[]
-        {
+            ("03", "Serviços de terminais rodoviários, ferroviários e metroviários"),
+        ]),
+        ("21", [("01", "Serviços de registros públicos, cartorários e notariais")]),
+        ("22", [("01", "Serviços de exploração de rodovia mediante cobrança de pedágio")]),
+        ("23", [("01", "Serviços de programação e comunicação visual, desenho industrial")]),
+        ("24", [("01", "Serviços de chaveiros, confecção de carimbos, placas, banners")]),
+        ("25", [
             ("01", "Funerais, inclusive fornecimento de caixão e urna"),
             ("02", "Cremação de corpos e partes de corpos cadavéricos"),
             ("03", "Planos ou convênio funerários"),
             ("04", "Manutenção e conservação de jazigos e cemitérios"),
-            ("05", "Cessão de uso de espaços em cemitérios para sepultamento")
-        });
-
-        AddServicos(servicos, "26", "Serviços de coleta, remessa ou entrega de correspondências, documentos, objetos, bens ou valores", new[]
-        {
-            ("01", "Serviços de coleta, remessa ou entrega de correspondências e objetos")
-        });
-
-        AddServicos(servicos, "27", "Serviços de assistência social", new[]
-        {
-            ("01", "Serviços de assistência social")
-        });
-
-        AddServicos(servicos, "28", "Serviços de avaliação de bens e serviços de qualquer natureza", new[]
-        {
-            ("01", "Serviços de avaliação de bens e serviços de qualquer natureza")
-        });
-
-        AddServicos(servicos, "29", "Serviços de biblioteconomia", new[]
-        {
-            ("01", "Serviços de biblioteconomia")
-        });
-
-        AddServicos(servicos, "30", "Serviços de biologia, biotecnologia e química", new[]
-        {
-            ("01", "Serviços de biologia, biotecnologia e química")
-        });
-
-        AddServicos(servicos, "31", "Serviços técnicos em edificações, eletrônica, eletrotécnica, mecânica, telecomunicações e congêneres", new[]
-        {
-            ("01", "Serviços técnicos em edificações, eletrônica, eletrotécnica, mecânica e telecomunicações")
-        });
-
-        AddServicos(servicos, "32", "Serviços de desenhos técnicos", new[]
-        {
-            ("01", "Serviços de desenhos técnicos")
-        });
-
-        AddServicos(servicos, "33", "Serviços de desembaraço aduaneiro, comissários, despachantes e congêneres", new[]
-        {
-            ("01", "Serviços de desembaraço aduaneiro, comissários e despachantes")
-        });
-
-        AddServicos(servicos, "34", "Serviços de investigações particulares, detetives e congêneres", new[]
-        {
-            ("01", "Serviços de investigações particulares, detetives e congêneres")
-        });
-
-        AddServicos(servicos, "35", "Serviços de reportagem, assessoria de imprensa, jornalismo e relações públicas", new[]
-        {
-            ("01", "Serviços de reportagem, assessoria de imprensa, jornalismo e relações públicas")
-        });
-
-        AddServicos(servicos, "36", "Serviços de meteorologia", new[]
-        {
-            ("01", "Serviços de meteorologia")
-        });
-
-        AddServicos(servicos, "37", "Serviços de artistas, atletas, modelos e manequins", new[]
-        {
-            ("01", "Serviços de artistas, atletas, modelos e manequins")
-        });
-
-        AddServicos(servicos, "38", "Serviços de museologia", new[]
-        {
-            ("01", "Serviços de museologia")
-        });
-
-        AddServicos(servicos, "39", "Serviços de ourivesaria e lapidação", new[]
-        {
-            ("01", "Serviços de ourivesaria e lapidação de metais preciosos, pedras e afins")
-        });
-
-        AddServicos(servicos, "40", "Serviços relativos a obras de arte sob encomenda", new[]
-        {
-            ("01", "Obras de arte sob encomenda")
-        });
-
-        return servicos;
-    }
-
-    private static void AddServicos(
-        List<Servico> servicos,
-        string item,
-        string descricaoItem,
-        (string subitem, string descricao)[] subitens)
-    {
-        foreach (var (subitem, descricao) in subitens)
-        {
-            // Formato: ii.ss.dd (item.subitem.desdobramento)
-            // Desdobramento 00 = sem desdobramento
-            var codigo = $"{item}.{subitem}.00";
-            servicos.Add(Servico.Create(codigo, descricao, item, subitem, "00"));
-        }
-    }
+            ("05", "Cessão de uso de espaços em cemitérios para sepultamento"),
+        ]),
+        ("26", [("01", "Serviços de coleta, remessa ou entrega de correspondências e objetos")]),
+        ("27", [("01", "Serviços de assistência social")]),
+        ("28", [("01", "Serviços de avaliação de bens e serviços de qualquer natureza")]),
+        ("29", [("01", "Serviços de biblioteconomia")]),
+        ("30", [("01", "Serviços de biologia, biotecnologia e química")]),
+        ("31", [("01", "Serviços técnicos em edificações, eletrônica, eletrotécnica, mecânica e telecomunicações")]),
+        ("32", [("01", "Serviços de desenhos técnicos")]),
+        ("33", [("01", "Serviços de desembaraço aduaneiro, comissários e despachantes")]),
+        ("34", [("01", "Serviços de investigações particulares, detetives e congêneres")]),
+        ("35", [("01", "Serviços de reportagem, assessoria de imprensa, jornalismo e relações públicas")]),
+        ("36", [("01", "Serviços de meteorologia")]),
+        ("37", [("01", "Serviços de artistas, atletas, modelos e manequins")]),
+        ("38", [("01", "Serviços de museologia")]),
+        ("39", [("01", "Serviços de ourivesaria e lapidação de metais preciosos, pedras e afins")]),
+        ("40", [("01", "Obras de arte sob encomenda")]),
+    ];
 }

--- a/backend/MapaTributário/src/MapaTributario.API/Infrastructure/Seed/ServicoSeedService.cs
+++ b/backend/MapaTributário/src/MapaTributario.API/Infrastructure/Seed/ServicoSeedService.cs
@@ -1,0 +1,420 @@
+using MapaTributario.API.Domain.Entities;
+using MapaTributario.API.Domain.Interfaces;
+
+namespace MapaTributario.API.Infrastructure.Seed;
+
+public class ServicoSeedService
+{
+    private readonly IServicoRepository _servicoRepository;
+    private readonly ILogger<ServicoSeedService> _logger;
+
+    public ServicoSeedService(
+        IServicoRepository servicoRepository,
+        ILogger<ServicoSeedService> logger)
+    {
+        _servicoRepository = servicoRepository;
+        _logger = logger;
+    }
+
+    public async Task SeedAsync()
+    {
+        var count = await _servicoRepository.CountAsync();
+        if (count > 0)
+        {
+            _logger.LogInformation("Serviços já existem ({Count} registros). Seed ignorado.", count);
+            return;
+        }
+
+        var servicos = GerarServicosLc116();
+        await _servicoRepository.InsertManyAsync(servicos);
+        _logger.LogInformation("Seed de serviços concluído: {Count} códigos de tributação inseridos.", servicos.Count);
+    }
+
+    private static List<Servico> GerarServicosLc116()
+    {
+        var servicos = new List<Servico>();
+
+        // LC 116/2003 - 40 itens principais com subitens comuns
+        // Formato código tributação nacional: ii.ss.dd (item.subitem.desdobramento)
+
+        AddServicos(servicos, "01", "Serviços de informática e congêneres", new[]
+        {
+            ("01", "Análise e desenvolvimento de sistemas"),
+            ("02", "Programação"),
+            ("03", "Processamento, armazenamento ou hospedagem de dados"),
+            ("04", "Elaboração de programas de computadores"),
+            ("05", "Licenciamento ou cessão de uso de programas de computação"),
+            ("06", "Assessoria e consultoria em informática"),
+            ("07", "Suporte técnico em informática"),
+            ("08", "Planejamento, confecção, manutenção de páginas eletrônicas"),
+            ("09", "Disponibilização de conteúdos de áudio, vídeo, imagem e texto")
+        });
+
+        AddServicos(servicos, "02", "Serviços de pesquisas e desenvolvimento de qualquer natureza", new[]
+        {
+            ("01", "Serviços de pesquisas e desenvolvimento de qualquer natureza")
+        });
+
+        AddServicos(servicos, "03", "Serviços prestados mediante locação, cessão de direito de uso e congêneres", new[]
+        {
+            ("02", "Cessão de direito de uso de marcas e sinais de propaganda"),
+            ("03", "Exploração de salões de festas e outros espaços"),
+            ("04", "Locação, sublocação, arrendamento de bens"),
+            ("05", "Cessão de andaimes, palcos e estruturas de uso temporário")
+        });
+
+        AddServicos(servicos, "04", "Serviços de saúde, assistência médica e congêneres", new[]
+        {
+            ("01", "Medicina e biomedicina"),
+            ("02", "Análises clínicas, patologia e eletricidade médica"),
+            ("03", "Hospitais, clínicas, laboratórios, sanatórios e congêneres"),
+            ("04", "Instrumentação cirúrgica"),
+            ("05", "Acupuntura"),
+            ("06", "Enfermagem e terapia ocupacional"),
+            ("07", "Serviços farmacêuticos"),
+            ("08", "Terapia de qualquer espécie"),
+            ("09", "Nutrição"),
+            ("10", "Obstetrícia"),
+            ("11", "Odontologia"),
+            ("12", "Ortóptica"),
+            ("13", "Próteses sob encomenda"),
+            ("14", "Psicanálise"),
+            ("15", "Psicologia"),
+            ("16", "Casas de repouso e de recuperação"),
+            ("17", "Bancos de sangue, leite, pele, olhos, óvulos"),
+            ("18", "Coleta de sangue, leite, tecidos e congêneres"),
+            ("19", "Unidade de atendimento, assistência ou tratamento móvel"),
+            ("20", "Planos de medicina de grupo ou individual"),
+            ("21", "Outros planos de saúde"),
+            ("22", "Outros serviços de saúde"),
+            ("23", "Serviços de saúde prestados em regime de home care")
+        });
+
+        AddServicos(servicos, "05", "Serviços de medicina e assistência veterinária e congêneres", new[]
+        {
+            ("01", "Medicina veterinária e zootecnia"),
+            ("02", "Hospitais, clínicas e ambulatórios veterinários"),
+            ("03", "Laboratórios de análise na área veterinária"),
+            ("04", "Inseminação artificial, fertilização e congêneres"),
+            ("05", "Bancos de sangue e de órgãos veterinários"),
+            ("06", "Tosa, banho e embelezamento de animais"),
+            ("07", "Guarda, tratamento, amestramento e adestramento"),
+            ("08", "Ensino e treinamento de animais"),
+            ("09", "Planos de atendimento e assistência veterinária")
+        });
+
+        AddServicos(servicos, "06", "Serviços de cuidados pessoais, estética, atividades físicas e congêneres", new[]
+        {
+            ("01", "Barbearia, cabeleireiros e congêneres"),
+            ("02", "Esteticistas, tratamento de pele e congêneres"),
+            ("03", "Banhos, duchas, sauna e massagens"),
+            ("04", "Ginástica, dança, esportes e congêneres"),
+            ("05", "Centros de emagrecimento, spa e congêneres"),
+            ("06", "Aplicação de tatuagens, piercings e congêneres")
+        });
+
+        AddServicos(servicos, "07", "Serviços relativos a engenharia, arquitetura, geologia, urbanismo, construção civil e congêneres", new[]
+        {
+            ("01", "Engenharia, agronomia, agrimensura e congêneres"),
+            ("02", "Execução de obras de construção civil e hidráulica"),
+            ("03", "Elaboração de planos diretores e projetos"),
+            ("04", "Demolição"),
+            ("05", "Reparação, conservação e reforma de edifícios"),
+            ("06", "Colocação e instalação de tapetes e cortinas"),
+            ("07", "Recuperação, raspagem, polimento e lustração de pisos"),
+            ("08", "Calafetação"),
+            ("09", "Varrição, coleta, remoção e incineração de lixo"),
+            ("10", "Limpeza, manutenção e conservação de imóveis"),
+            ("11", "Decoração e jardinagem"),
+            ("12", "Controle e tratamento de efluentes"),
+            ("13", "Dedetização, desinfecção e desinsetização"),
+            ("14", "Florestamento, reflorestamento e semeadura"),
+            ("15", "Escoramento, contenção de encostas e congêneres"),
+            ("16", "Limpeza e dragagem"),
+            ("17", "Acompanhamento e fiscalização de obras"),
+            ("18", "Aerofotogrametria e cartografia"),
+            ("19", "Pesquisa, perfuração, cimentação e perfilagem de poços"),
+            ("20", "Nucleação e bombardeamento de nuvens"),
+            ("21", "Serviços de topografia"),
+            ("22", "Serviços de geologia e geotécnica")
+        });
+
+        AddServicos(servicos, "08", "Serviços de educação, ensino, orientação pedagógica e educacional, instrução, treinamento e avaliação pessoal", new[]
+        {
+            ("01", "Ensino regular pré-escolar, fundamental, médio e superior"),
+            ("02", "Instrução, treinamento, orientação pedagógica, avaliação")
+        });
+
+        AddServicos(servicos, "09", "Serviços relativos a hospedagem, turismo, viagens e congêneres", new[]
+        {
+            ("01", "Hospedagem em hotéis, apart-hotéis e congêneres"),
+            ("02", "Agenciamento, organização e promoção de turismo"),
+            ("03", "Guias de turismo")
+        });
+
+        AddServicos(servicos, "10", "Serviços de intermediação e congêneres", new[]
+        {
+            ("01", "Agenciamento, corretagem de câmbio, seguros e congêneres"),
+            ("02", "Agenciamento, corretagem de títulos em geral"),
+            ("03", "Agenciamento, corretagem de contratos de arrendamento mercantil"),
+            ("04", "Agenciamento, corretagem de contratos de franquia"),
+            ("05", "Agenciamento, corretagem de imóveis"),
+            ("06", "Agenciamento marítimo"),
+            ("07", "Agenciamento de notícias"),
+            ("08", "Agenciamento de publicidade e propaganda"),
+            ("09", "Representação de qualquer natureza"),
+            ("10", "Distribuição de bens de terceiros")
+        });
+
+        AddServicos(servicos, "11", "Serviços de guarda, estacionamento, armazenamento, vigilância e congêneres", new[]
+        {
+            ("01", "Guarda e estacionamento de veículos"),
+            ("02", "Vigilância, segurança ou monitoramento"),
+            ("03", "Escolta, inclusive de veículos e cargas"),
+            ("04", "Armazenamento, depósito, carga e descarga")
+        });
+
+        AddServicos(servicos, "12", "Serviços de diversões, lazer, entretenimento e congêneres", new[]
+        {
+            ("01", "Espetáculos teatrais"),
+            ("02", "Exibições cinematográficas"),
+            ("03", "Espetáculos circenses"),
+            ("04", "Programas de auditório"),
+            ("05", "Parques de diversões, centros de lazer"),
+            ("06", "Boates, taxi-dancing e congêneres"),
+            ("07", "Shows, ballet, danças, desfiles e congêneres"),
+            ("08", "Feiras, exposições, congressos e congêneres"),
+            ("09", "Bilhares, boliches e diversões eletrônicas"),
+            ("10", "Corridas e competições de animais"),
+            ("11", "Competições esportivas ou de destreza"),
+            ("12", "Execução de música"),
+            ("13", "Produção de eventos e shows"),
+            ("14", "Fornecimento de música para ambientes"),
+            ("15", "Desfiles de blocos carnavalescos"),
+            ("16", "Exibição de filmes e espetáculos"),
+            ("17", "Recreação e animação")
+        });
+
+        AddServicos(servicos, "13", "Serviços relativos a fonografia, fotografia, cinematografia e reprografia", new[]
+        {
+            ("01", "Fonografia"),
+            ("02", "Fotografia e cinematografia"),
+            ("03", "Reprografia, microfilmagem e digitalização"),
+            ("04", "Composição gráfica e fotocomposição"),
+            ("05", "Composição gráfica, inclusive confecção de impressos gráficos")
+        });
+
+        AddServicos(servicos, "14", "Serviços relativos a bens de terceiros", new[]
+        {
+            ("01", "Lubrificação, limpeza, lustração, revisão de máquinas"),
+            ("02", "Assistência técnica"),
+            ("03", "Recondicionamento de motores"),
+            ("04", "Recauchutagem ou regeneração de pneus"),
+            ("05", "Restauração, recondicionamento de quaisquer objetos"),
+            ("06", "Instalação e montagem de aparelhos e equipamentos"),
+            ("07", "Colocação de molduras e afins"),
+            ("08", "Encadernação, gravação e douração"),
+            ("09", "Alfaiataria e costura"),
+            ("10", "Tinturaria e lavanderia"),
+            ("11", "Tapeçaria e reforma de estofamentos"),
+            ("12", "Funilaria e lanternagem"),
+            ("13", "Carpintaria e serralheria"),
+            ("14", "Guincho intramunicipal, guindaste e içamento")
+        });
+
+        AddServicos(servicos, "15", "Serviços relacionados ao setor bancário ou financeiro", new[]
+        {
+            ("01", "Administração de fundos, consórcio e cartão de crédito"),
+            ("02", "Abertura de contas"),
+            ("03", "Locação e manutenção de cofres"),
+            ("04", "Fornecimento ou emissão de atestados"),
+            ("05", "Cadastro, elaboração de ficha cadastral"),
+            ("06", "Emissão, reemissão e fornecimento de avisos"),
+            ("07", "Acesso, movimentação e consulta a contas"),
+            ("08", "Emissão, reemissão, alteração de contratos de câmbio"),
+            ("09", "Arrendamento mercantil (leasing)"),
+            ("10", "Serviços de cobranças, recebimentos ou pagamentos"),
+            ("11", "Devolução de títulos"),
+            ("12", "Sustação de protesto"),
+            ("13", "Fornecimento de segunda via de documentos"),
+            ("14", "Emissão de certificados"),
+            ("15", "Compensação de cheques e títulos"),
+            ("16", "Emissão, fornecimento de documentos bancários"),
+            ("17", "Concessão, revisão, retificação de empréstimos"),
+            ("18", "Emissão, concessão, alteração de cartão de crédito")
+        });
+
+        AddServicos(servicos, "16", "Serviços de transporte de natureza municipal", new[]
+        {
+            ("01", "Serviços de transporte coletivo municipal rodoviário"),
+            ("02", "Outros serviços de transporte de natureza municipal")
+        });
+
+        AddServicos(servicos, "17", "Serviços de apoio técnico, administrativo, jurídico, contábil, comercial e congêneres", new[]
+        {
+            ("01", "Assessoria ou consultoria de qualquer natureza"),
+            ("02", "Datilografia, digitação, estenografia e congêneres"),
+            ("03", "Planejamento, coordenação, programação e organização técnica"),
+            ("04", "Recrutamento, seleção e colocação de mão-de-obra"),
+            ("05", "Fornecimento de mão-de-obra, mesmo em caráter temporário"),
+            ("06", "Propaganda e publicidade"),
+            ("07", "Franquia (franchising)"),
+            ("08", "Perícias, laudos, exames técnicos e análises técnicas"),
+            ("09", "Planejamento, organização e administração de feiras"),
+            ("10", "Organização de festas e recepções"),
+            ("11", "Administração em geral, inclusive de bens e negócios"),
+            ("12", "Leilão e congêneres"),
+            ("13", "Advocacia"),
+            ("14", "Arbitragem de qualquer espécie"),
+            ("15", "Auditoria"),
+            ("16", "Análise de Organização e Métodos"),
+            ("17", "Atuária e cálculos técnicos"),
+            ("18", "Contabilidade e auditoria"),
+            ("19", "Consultoria e assessoria econômica ou financeira"),
+            ("20", "Estatística"),
+            ("21", "Cobrança em geral"),
+            ("22", "Assessoria, análise, avaliação e informações de risco"),
+            ("23", "Apresentação de palestras, conferências e seminários"),
+            ("24", "Inserção de textos, desenhos e outros materiais de propaganda"),
+            ("25", "Serviços de investigações particulares, detetives e congêneres")
+        });
+
+        AddServicos(servicos, "18", "Serviços de regulação de sinistros vinculados a contratos de seguros", new[]
+        {
+            ("01", "Serviços de regulação de sinistros")
+        });
+
+        AddServicos(servicos, "19", "Serviços de distribuição e venda de bilhetes e demais produtos de loteria", new[]
+        {
+            ("01", "Serviços de distribuição e venda de bilhetes de loteria")
+        });
+
+        AddServicos(servicos, "20", "Serviços portuários, aeroportuários, ferroportuários, de terminais rodoviários, ferroviários e metroviários", new[]
+        {
+            ("01", "Serviços portuários e ferroportuários"),
+            ("02", "Serviços aeroportuários"),
+            ("03", "Serviços de terminais rodoviários, ferroviários e metroviários")
+        });
+
+        AddServicos(servicos, "21", "Serviços de registros públicos, cartorários e notariais", new[]
+        {
+            ("01", "Serviços de registros públicos, cartorários e notariais")
+        });
+
+        AddServicos(servicos, "22", "Serviços de exploração de rodovia", new[]
+        {
+            ("01", "Serviços de exploração de rodovia mediante cobrança de pedágio")
+        });
+
+        AddServicos(servicos, "23", "Serviços de programação e comunicação visual, desenho industrial e congêneres", new[]
+        {
+            ("01", "Serviços de programação e comunicação visual, desenho industrial")
+        });
+
+        AddServicos(servicos, "24", "Serviços de chaveiros, confecção de carimbos, placas, sinalização visual, banners, adesivos e congêneres", new[]
+        {
+            ("01", "Serviços de chaveiros, confecção de carimbos, placas, banners")
+        });
+
+        AddServicos(servicos, "25", "Serviços funerários", new[]
+        {
+            ("01", "Funerais, inclusive fornecimento de caixão e urna"),
+            ("02", "Cremação de corpos e partes de corpos cadavéricos"),
+            ("03", "Planos ou convênio funerários"),
+            ("04", "Manutenção e conservação de jazigos e cemitérios"),
+            ("05", "Cessão de uso de espaços em cemitérios para sepultamento")
+        });
+
+        AddServicos(servicos, "26", "Serviços de coleta, remessa ou entrega de correspondências, documentos, objetos, bens ou valores", new[]
+        {
+            ("01", "Serviços de coleta, remessa ou entrega de correspondências e objetos")
+        });
+
+        AddServicos(servicos, "27", "Serviços de assistência social", new[]
+        {
+            ("01", "Serviços de assistência social")
+        });
+
+        AddServicos(servicos, "28", "Serviços de avaliação de bens e serviços de qualquer natureza", new[]
+        {
+            ("01", "Serviços de avaliação de bens e serviços de qualquer natureza")
+        });
+
+        AddServicos(servicos, "29", "Serviços de biblioteconomia", new[]
+        {
+            ("01", "Serviços de biblioteconomia")
+        });
+
+        AddServicos(servicos, "30", "Serviços de biologia, biotecnologia e química", new[]
+        {
+            ("01", "Serviços de biologia, biotecnologia e química")
+        });
+
+        AddServicos(servicos, "31", "Serviços técnicos em edificações, eletrônica, eletrotécnica, mecânica, telecomunicações e congêneres", new[]
+        {
+            ("01", "Serviços técnicos em edificações, eletrônica, eletrotécnica, mecânica e telecomunicações")
+        });
+
+        AddServicos(servicos, "32", "Serviços de desenhos técnicos", new[]
+        {
+            ("01", "Serviços de desenhos técnicos")
+        });
+
+        AddServicos(servicos, "33", "Serviços de desembaraço aduaneiro, comissários, despachantes e congêneres", new[]
+        {
+            ("01", "Serviços de desembaraço aduaneiro, comissários e despachantes")
+        });
+
+        AddServicos(servicos, "34", "Serviços de investigações particulares, detetives e congêneres", new[]
+        {
+            ("01", "Serviços de investigações particulares, detetives e congêneres")
+        });
+
+        AddServicos(servicos, "35", "Serviços de reportagem, assessoria de imprensa, jornalismo e relações públicas", new[]
+        {
+            ("01", "Serviços de reportagem, assessoria de imprensa, jornalismo e relações públicas")
+        });
+
+        AddServicos(servicos, "36", "Serviços de meteorologia", new[]
+        {
+            ("01", "Serviços de meteorologia")
+        });
+
+        AddServicos(servicos, "37", "Serviços de artistas, atletas, modelos e manequins", new[]
+        {
+            ("01", "Serviços de artistas, atletas, modelos e manequins")
+        });
+
+        AddServicos(servicos, "38", "Serviços de museologia", new[]
+        {
+            ("01", "Serviços de museologia")
+        });
+
+        AddServicos(servicos, "39", "Serviços de ourivesaria e lapidação", new[]
+        {
+            ("01", "Serviços de ourivesaria e lapidação de metais preciosos, pedras e afins")
+        });
+
+        AddServicos(servicos, "40", "Serviços relativos a obras de arte sob encomenda", new[]
+        {
+            ("01", "Obras de arte sob encomenda")
+        });
+
+        return servicos;
+    }
+
+    private static void AddServicos(
+        List<Servico> servicos,
+        string item,
+        string descricaoItem,
+        (string subitem, string descricao)[] subitens)
+    {
+        foreach (var (subitem, descricao) in subitens)
+        {
+            // Formato: ii.ss.dd (item.subitem.desdobramento)
+            // Desdobramento 00 = sem desdobramento
+            var codigo = $"{item}.{subitem}.00";
+            servicos.Add(Servico.Create(codigo, descricao, item, subitem, "00"));
+        }
+    }
+}

--- a/backend/MapaTributário/src/MapaTributario.API/MapaTributario.API.csproj
+++ b/backend/MapaTributário/src/MapaTributario.API/MapaTributario.API.csproj
@@ -7,6 +7,12 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <None Include="..\..\..\..\context\municipios.json" Link="context\municipios.json">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+    </ItemGroup>
+
+    <ItemGroup>
         <PackageReference Include="BCrypt.Net-Next" Version="4.1.0" />
         <PackageReference Include="FluentResults" Version="4.0.0" />
         <PackageReference Include="FluentValidation" Version="12.1.1" />

--- a/backend/MapaTributário/src/MapaTributario.API/Program.cs
+++ b/backend/MapaTributário/src/MapaTributario.API/Program.cs
@@ -57,7 +57,7 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
 builder.Services.AddAuthorization();
 
 // Consulta services (PBI #4)
-// builder.Services.AddConsultaServices(builder.Configuration);
+builder.Services.AddConsultaServices(builder.Configuration);
 
 // Crawler services (PBI #5)
 // builder.Services.AddCrawlerServices(builder.Configuration);
@@ -67,6 +67,9 @@ builder.Services.AddControllers();
 builder.Services.AddOpenApi();
 
 var app = builder.Build();
+
+// Run seeds (idempotent)
+await app.RunConsultaSeedsAsync();
 
 app.UseMiddleware<ErrorHandlingMiddleware>();
 

--- a/backend/MapaTributário/src/MapaTributario.API/Validators/AliquotaQueryParamsValidator.cs
+++ b/backend/MapaTributário/src/MapaTributario.API/Validators/AliquotaQueryParamsValidator.cs
@@ -1,0 +1,28 @@
+using FluentValidation;
+using MapaTributario.API.Application.Consulta.Contracts;
+
+namespace MapaTributario.API.Validators;
+
+public class AliquotaQueryParamsValidator : AbstractValidator<AliquotaQueryParams>
+{
+    public AliquotaQueryParamsValidator()
+    {
+        RuleFor(x => x.Pagina)
+            .GreaterThanOrEqualTo(1).WithMessage("Página deve ser maior ou igual a 1");
+
+        RuleFor(x => x.TamanhoPagina)
+            .InclusiveBetween(1, 100).WithMessage("Tamanho da página deve ser entre 1 e 100");
+
+        RuleFor(x => x.AliquotaMin)
+            .GreaterThanOrEqualTo(0).When(x => x.AliquotaMin.HasValue)
+            .WithMessage("Alíquota mínima deve ser maior ou igual a 0");
+
+        RuleFor(x => x.AliquotaMax)
+            .GreaterThanOrEqualTo(0).When(x => x.AliquotaMax.HasValue)
+            .WithMessage("Alíquota máxima deve ser maior ou igual a 0");
+
+        RuleFor(x => x)
+            .Must(x => !x.AliquotaMin.HasValue || !x.AliquotaMax.HasValue || x.AliquotaMin <= x.AliquotaMax)
+            .WithMessage("Alíquota mínima não pode ser maior que a alíquota máxima");
+    }
+}

--- a/backend/MapaTributário/tests/MapaTributario.Tests.Integration/ConsultaControllerTests.cs
+++ b/backend/MapaTributário/tests/MapaTributario.Tests.Integration/ConsultaControllerTests.cs
@@ -218,6 +218,37 @@ public class ConsultaControllerTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task GET_AliquotasPorMunicipio_FiltroPrefixoCodigoServico_RetornaMultiplos()
+    {
+        var response = await _client.GetAsync("/api/v1/municipios/3550308/aliquotas?codigoServico=01");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var paginado = await response.Content.ReadFromJsonAsync<PaginatedResponse<AliquotaResponse>>();
+        paginado.ShouldNotBeNull();
+        paginado.Items.Count.ShouldBe(3); // 010100, 010200, 010300 all start with "01"
+    }
+
+    [Fact]
+    public async Task GET_AliquotasPorMunicipio_FiltroPrefixo4Digitos_RetornaFiltrado()
+    {
+        var response = await _client.GetAsync("/api/v1/municipios/3550308/aliquotas?codigoServico=01.01");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var paginado = await response.Content.ReadFromJsonAsync<PaginatedResponse<AliquotaResponse>>();
+        paginado.ShouldNotBeNull();
+        paginado.Items.Count.ShouldBe(1);
+        paginado.Items[0].CodigoServicoFormatado.ShouldBe("01.01.00");
+    }
+
+    [Fact]
+    public async Task GET_AliquotasPorMunicipio_CodigoServicoInvalido_Retorna400()
+    {
+        var response = await _client.GetAsync("/api/v1/municipios/3550308/aliquotas?codigoServico=abc");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
     public async Task GET_AliquotasPorMunicipio_FiltroDescricao_Funciona()
     {
         var response = await _client.GetAsync("/api/v1/municipios/3550308/aliquotas?descricao=Programa");

--- a/backend/MapaTributário/tests/MapaTributario.Tests.Integration/ConsultaControllerTests.cs
+++ b/backend/MapaTributário/tests/MapaTributario.Tests.Integration/ConsultaControllerTests.cs
@@ -1,0 +1,325 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using MapaTributario.API.Application.Auth.Contracts;
+using MapaTributario.API.Application.Consulta.Contracts;
+using MapaTributario.API.Domain.Entities;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using MongoDB.Driver;
+using Shouldly;
+using Testcontainers.MongoDb;
+
+namespace MapaTributario.Tests.Integration;
+
+public class ConsultaControllerTests : IAsyncLifetime
+{
+    private readonly MongoDbContainer _mongoContainer = new MongoDbBuilder()
+        .WithImage("mongo:7")
+        .Build();
+
+    private WebApplicationFactory<Program> _factory = null!;
+    private HttpClient _client = null!;
+    private IMongoDatabase _database = null!;
+
+    public async Task InitializeAsync()
+    {
+        await _mongoContainer.StartAsync();
+
+        var mongoClient = new MongoClient(_mongoContainer.GetConnectionString());
+        _database = mongoClient.GetDatabase("test_db");
+
+        _factory = new WebApplicationFactory<Program>()
+            .WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureServices(services =>
+                {
+                    var descriptor = services.SingleOrDefault(d => d.ServiceType == typeof(IMongoDatabase));
+                    if (descriptor is not null)
+                    {
+                        services.Remove(descriptor);
+                    }
+
+                    services.AddSingleton<IMongoDatabase>(_database);
+                });
+            });
+
+        _client = _factory.CreateClient();
+
+        await SeedTestDataAsync();
+        await AuthenticateAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        _client.Dispose();
+        await _factory.DisposeAsync();
+        await _mongoContainer.DisposeAsync();
+    }
+
+    private async Task SeedTestDataAsync()
+    {
+        // Seed aliquotas for testing (estados, municipios and servicos are seeded by the app startup)
+        var aliquotas = _database.GetCollection<Aliquota>("aliquotas");
+
+        var testAliquotas = new List<Aliquota>
+        {
+            Aliquota.Create("3550308", "São Paulo", "010100", "01.01.00", "Análise e desenvolvimento de sistemas", 2.0m, "2024-01", "NFS-e"),
+            Aliquota.Create("3550308", "São Paulo", "010200", "01.02.00", "Programação", 3.0m, "2024-01", "NFS-e"),
+            Aliquota.Create("3550308", "São Paulo", "010300", "01.03.00", "Processamento de dados", 5.0m, "2024-01", "NFS-e"),
+            Aliquota.Create("3304557", "Rio de Janeiro", "010100", "01.01.00", "Análise e desenvolvimento de sistemas", 2.5m, "2024-01", "NFS-e"),
+            Aliquota.Create("3304557", "Rio de Janeiro", "010200", "01.02.00", "Programação", 4.0m, "2024-02", "NFS-e")
+        };
+
+        await aliquotas.InsertManyAsync(testAliquotas);
+    }
+
+    private async Task AuthenticateAsync()
+    {
+        var registerReq = new RegisterRequest
+        {
+            Email = "consulta@test.com",
+            Nome = "Consulta Test",
+            Senha = "password123"
+        };
+        var registerResp = await _client.PostAsJsonAsync("/api/v1/auth/register", registerReq);
+        var tokens = await registerResp.Content.ReadFromJsonAsync<AuthResponse>();
+        _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", tokens!.AccessToken);
+    }
+
+    // --- Auth ---
+
+    [Fact]
+    public async Task GET_Estados_SemToken_Retorna401()
+    {
+        var unauthClient = _factory.CreateClient();
+
+        var response = await unauthClient.GetAsync("/api/v1/estados");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+        unauthClient.Dispose();
+    }
+
+    // --- Estados ---
+
+    [Fact]
+    public async Task GET_Estados_Retorna200_ComEstados()
+    {
+        var response = await _client.GetAsync("/api/v1/estados");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var estados = await response.Content.ReadFromJsonAsync<List<EstadoResponse>>();
+        estados.ShouldNotBeNull();
+        estados.Count.ShouldBe(27);
+        estados.First().Sigla.ShouldNotBeNullOrEmpty();
+        estados.First().Nome.ShouldNotBeNullOrEmpty();
+        estados.First().Regiao.ShouldNotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task GET_Estados_EstaoOrdenadosPorNome()
+    {
+        var response = await _client.GetAsync("/api/v1/estados");
+        var estados = await response.Content.ReadFromJsonAsync<List<EstadoResponse>>();
+
+        estados.ShouldNotBeNull();
+        var nomes = estados.Select(e => e.Nome).ToList();
+        // MongoDB uses binary sort by default (accent-insensitive ordering may differ from .NET)
+        // Verify the list is returned sorted by checking adjacent pairs via MongoDB's own sort
+        var nomesOrdenadosMongo = nomes.OrderBy(n => n, StringComparer.Ordinal).ToList();
+        nomes.ShouldBe(nomesOrdenadosMongo);
+    }
+
+    // --- Municipios por UF ---
+
+    [Fact]
+    public async Task GET_MunicipiosPorUf_UfValida_Retorna200()
+    {
+        var response = await _client.GetAsync("/api/v1/estados/SP/municipios");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var municipios = await response.Content.ReadFromJsonAsync<List<MunicipioResponse>>();
+        municipios.ShouldNotBeNull();
+        municipios.Count.ShouldBeGreaterThan(0);
+        municipios.All(m => m.SiglaEstado == "SP").ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task GET_MunicipiosPorUf_UfInvalida_Retorna404()
+    {
+        var response = await _client.GetAsync("/api/v1/estados/XX/municipios");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task GET_MunicipiosPorUf_SemToken_Retorna401()
+    {
+        var unauthClient = _factory.CreateClient();
+
+        var response = await unauthClient.GetAsync("/api/v1/estados/SP/municipios");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+        unauthClient.Dispose();
+    }
+
+    // --- Aliquotas por municipio ---
+
+    [Fact]
+    public async Task GET_AliquotasPorMunicipio_Retorna200_ComPaginacao()
+    {
+        var response = await _client.GetAsync("/api/v1/municipios/3550308/aliquotas");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var paginado = await response.Content.ReadFromJsonAsync<PaginatedResponse<AliquotaResponse>>();
+        paginado.ShouldNotBeNull();
+        paginado.Items.Count.ShouldBe(3);
+        paginado.Pagina.ShouldBe(1);
+        paginado.TamanhoPagina.ShouldBe(20);
+        paginado.TotalItens.ShouldBe(3);
+        paginado.TotalPaginas.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task GET_AliquotasPorMunicipio_ComTamanhoPagina_LimitaResultados()
+    {
+        var response = await _client.GetAsync("/api/v1/municipios/3550308/aliquotas?tamanhoPagina=2&pagina=1");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var paginado = await response.Content.ReadFromJsonAsync<PaginatedResponse<AliquotaResponse>>();
+        paginado.ShouldNotBeNull();
+        paginado.Items.Count.ShouldBe(2);
+        paginado.TotalItens.ShouldBe(3);
+        paginado.TotalPaginas.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task GET_AliquotasPorMunicipio_Pagina2_RetornaRestante()
+    {
+        var response = await _client.GetAsync("/api/v1/municipios/3550308/aliquotas?tamanhoPagina=2&pagina=2");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var paginado = await response.Content.ReadFromJsonAsync<PaginatedResponse<AliquotaResponse>>();
+        paginado.ShouldNotBeNull();
+        paginado.Items.Count.ShouldBe(1);
+        paginado.Pagina.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task GET_AliquotasPorMunicipio_FiltroCodigoServico_Funciona()
+    {
+        var response = await _client.GetAsync("/api/v1/municipios/3550308/aliquotas?codigoServico=01.01.00");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var paginado = await response.Content.ReadFromJsonAsync<PaginatedResponse<AliquotaResponse>>();
+        paginado.ShouldNotBeNull();
+        paginado.Items.Count.ShouldBe(1);
+        paginado.Items[0].CodigoServicoFormatado.ShouldBe("01.01.00");
+    }
+
+    [Fact]
+    public async Task GET_AliquotasPorMunicipio_FiltroDescricao_Funciona()
+    {
+        var response = await _client.GetAsync("/api/v1/municipios/3550308/aliquotas?descricao=Programa");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var paginado = await response.Content.ReadFromJsonAsync<PaginatedResponse<AliquotaResponse>>();
+        paginado.ShouldNotBeNull();
+        paginado.Items.Count.ShouldBe(1);
+        paginado.Items[0].DescricaoServico.ShouldContain("Programação");
+    }
+
+    [Fact]
+    public async Task GET_AliquotasPorMunicipio_FiltroAliquotaMinMax_Funciona()
+    {
+        var response = await _client.GetAsync("/api/v1/municipios/3550308/aliquotas?aliquotaMin=2.5&aliquotaMax=4.0");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var paginado = await response.Content.ReadFromJsonAsync<PaginatedResponse<AliquotaResponse>>();
+        paginado.ShouldNotBeNull();
+        paginado.Items.Count.ShouldBe(1);
+        paginado.Items[0].ValorAliquota.ShouldBe(3.0m);
+    }
+
+    [Fact]
+    public async Task GET_AliquotasPorMunicipio_MunicipioInexistente_Retorna404()
+    {
+        var response = await _client.GetAsync("/api/v1/municipios/9999999/aliquotas");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task GET_AliquotasPorMunicipio_TamanhoPaginaInvalido_Retorna400()
+    {
+        var response = await _client.GetAsync("/api/v1/municipios/3550308/aliquotas?tamanhoPagina=0");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task GET_AliquotasPorMunicipio_SemToken_Retorna401()
+    {
+        var unauthClient = _factory.CreateClient();
+
+        var response = await unauthClient.GetAsync("/api/v1/municipios/3550308/aliquotas");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+        unauthClient.Dispose();
+    }
+
+    // --- Detalhe aliquota ---
+
+    [Fact]
+    public async Task GET_DetalheAliquota_Existente_Retorna200()
+    {
+        var response = await _client.GetAsync("/api/v1/municipios/3550308/aliquotas/01.01.00");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var detalhe = await response.Content.ReadFromJsonAsync<AliquotaDetalheResponse>();
+        detalhe.ShouldNotBeNull();
+        detalhe.CodigoMunicipio.ShouldBe("3550308");
+        detalhe.NomeMunicipio.ShouldBe("São Paulo");
+        detalhe.CodigoServicoFormatado.ShouldBe("01.01.00");
+        detalhe.ValorAliquota.ShouldBe(2.0m);
+        detalhe.Competencia.ShouldBe("2024-01");
+    }
+
+    [Fact]
+    public async Task GET_DetalheAliquota_CodigoSemPontos_Funciona()
+    {
+        var response = await _client.GetAsync("/api/v1/municipios/3550308/aliquotas/010100");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var detalhe = await response.Content.ReadFromJsonAsync<AliquotaDetalheResponse>();
+        detalhe.ShouldNotBeNull();
+        detalhe.CodigoServicoFormatado.ShouldBe("01.01.00");
+    }
+
+    [Fact]
+    public async Task GET_DetalheAliquota_Inexistente_Retorna404()
+    {
+        var response = await _client.GetAsync("/api/v1/municipios/3550308/aliquotas/99.00.00");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task GET_DetalheAliquota_MunicipioInexistente_Retorna404()
+    {
+        var response = await _client.GetAsync("/api/v1/municipios/9999999/aliquotas/01.01.00");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task GET_DetalheAliquota_SemToken_Retorna401()
+    {
+        var unauthClient = _factory.CreateClient();
+
+        var response = await unauthClient.GetAsync("/api/v1/municipios/3550308/aliquotas/01.01.00");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+        unauthClient.Dispose();
+    }
+}

--- a/backend/MapaTributário/tests/MapaTributario.Tests.Unit/CodigoServicoNormalizerTests.cs
+++ b/backend/MapaTributário/tests/MapaTributario.Tests.Unit/CodigoServicoNormalizerTests.cs
@@ -118,4 +118,52 @@ public class CodigoServicoNormalizerTests
         var resultado = CodigoServicoNormalizer.EhValido(entrada!);
         resultado.ShouldBe(esperado);
     }
+
+    // --- NormalizarPrefixo ---
+
+    [Theory]
+    [InlineData("01", "01")]
+    [InlineData("14", "14")]
+    public void NormalizarPrefixo_Grupo2Digitos_RetornaDigitos(string entrada, string esperado)
+    {
+        var resultado = CodigoServicoNormalizer.NormalizarPrefixo(entrada);
+        resultado.ShouldBe(esperado);
+    }
+
+    [Theory]
+    [InlineData("01.01", "0101")]
+    [InlineData("0101", "0101")]
+    [InlineData("14.01", "1401")]
+    public void NormalizarPrefixo_SubItem4Digitos_RetornaDigitos(string entrada, string esperado)
+    {
+        var resultado = CodigoServicoNormalizer.NormalizarPrefixo(entrada);
+        resultado.ShouldBe(esperado);
+    }
+
+    [Theory]
+    [InlineData("01.01.00", "010100")]
+    [InlineData("010100", "010100")]
+    [InlineData("14.01.00", "140100")]
+    public void NormalizarPrefixo_CodigoCompleto6Digitos_RetornaDigitos(string entrada, string esperado)
+    {
+        var resultado = CodigoServicoNormalizer.NormalizarPrefixo(entrada);
+        resultado.ShouldBe(esperado);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    [InlineData("  ")]
+    [InlineData("abc")]
+    [InlineData("1")]
+    [InlineData("123")]
+    [InlineData("12345")]
+    [InlineData("1234567")]
+    [InlineData("0A")]
+    [InlineData("01.0A")]
+    public void NormalizarPrefixo_FormatoInvalido_RetornaVazio(string? entrada)
+    {
+        var resultado = CodigoServicoNormalizer.NormalizarPrefixo(entrada!);
+        resultado.ShouldBe(string.Empty);
+    }
 }

--- a/backend/MapaTributário/tests/MapaTributario.Tests.Unit/CodigoServicoNormalizerTests.cs
+++ b/backend/MapaTributário/tests/MapaTributario.Tests.Unit/CodigoServicoNormalizerTests.cs
@@ -1,0 +1,121 @@
+using MapaTributario.API.Application.Consulta;
+using Shouldly;
+
+namespace MapaTributario.Tests.Unit;
+
+public class CodigoServicoNormalizerTests
+{
+    [Theory]
+    [InlineData("01.02.00", "010200")]
+    [InlineData("14.01.00", "140100")]
+    [InlineData("07.22.00", "072200")]
+    public void RemoverPontos_CodigoComPontos_RetornaSemPontos(string entrada, string esperado)
+    {
+        var resultado = CodigoServicoNormalizer.RemoverPontos(entrada);
+        resultado.ShouldBe(esperado);
+    }
+
+    [Theory]
+    [InlineData("010200")]
+    [InlineData("140100")]
+    public void RemoverPontos_CodigoSemPontos_RetornaMesmoValor(string entrada)
+    {
+        var resultado = CodigoServicoNormalizer.RemoverPontos(entrada);
+        resultado.ShouldBe(entrada);
+    }
+
+    [Fact]
+    public void RemoverPontos_Null_RetornaVazio()
+    {
+        var resultado = CodigoServicoNormalizer.RemoverPontos(null!);
+        resultado.ShouldBe(string.Empty);
+    }
+
+    [Fact]
+    public void RemoverPontos_Vazio_RetornaVazio()
+    {
+        var resultado = CodigoServicoNormalizer.RemoverPontos("");
+        resultado.ShouldBe(string.Empty);
+    }
+
+    [Theory]
+    [InlineData("010200", "01.02.00")]
+    [InlineData("140100", "14.01.00")]
+    [InlineData("072200", "07.22.00")]
+    public void Formatar_CodigoSemPontos_RetornaFormatado(string entrada, string esperado)
+    {
+        var resultado = CodigoServicoNormalizer.Formatar(entrada);
+        resultado.ShouldBe(esperado);
+    }
+
+    [Theory]
+    [InlineData("01.02.00", "01.02.00")]
+    public void Formatar_CodigoComPontos_RetornaFormatado(string entrada, string esperado)
+    {
+        var resultado = CodigoServicoNormalizer.Formatar(entrada);
+        resultado.ShouldBe(esperado);
+    }
+
+    [Fact]
+    public void Formatar_CodigoComTamanhoInvalido_RetornaOriginal()
+    {
+        var resultado = CodigoServicoNormalizer.Formatar("12345");
+        resultado.ShouldBe("12345");
+    }
+
+    [Fact]
+    public void Formatar_Null_RetornaVazio()
+    {
+        var resultado = CodigoServicoNormalizer.Formatar(null!);
+        resultado.ShouldBe(string.Empty);
+    }
+
+    [Theory]
+    [InlineData("01.02.00", "010200")]
+    [InlineData("010200", "010200")]
+    [InlineData("14.01.00", "140100")]
+    public void Normalizar_FormatoValido_RetornaSemPontos(string entrada, string esperado)
+    {
+        var resultado = CodigoServicoNormalizer.Normalizar(entrada);
+        resultado.ShouldBe(esperado);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    [InlineData("  ")]
+    [InlineData("abc")]
+    [InlineData("12345")]
+    [InlineData("1234567")]
+    [InlineData("01.02")]
+    [InlineData("01.AB.00")]
+    public void Normalizar_FormatoInvalido_RetornaVazio(string? entrada)
+    {
+        var resultado = CodigoServicoNormalizer.Normalizar(entrada!);
+        resultado.ShouldBe(string.Empty);
+    }
+
+    [Theory]
+    [InlineData("01.02.00", true)]
+    [InlineData("010200", true)]
+    [InlineData("14.01.00", true)]
+    [InlineData("140100", true)]
+    public void EhValido_FormatoCorreto_RetornaTrue(string entrada, bool esperado)
+    {
+        var resultado = CodigoServicoNormalizer.EhValido(entrada);
+        resultado.ShouldBe(esperado);
+    }
+
+    [Theory]
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    [InlineData("abc", false)]
+    [InlineData("12345", false)]
+    [InlineData("1234567", false)]
+    [InlineData("01.02", false)]
+    public void EhValido_FormatoIncorreto_RetornaFalse(string? entrada, bool esperado)
+    {
+        var resultado = CodigoServicoNormalizer.EhValido(entrada!);
+        resultado.ShouldBe(esperado);
+    }
+}

--- a/backend/MapaTributário/tests/MapaTributario.Tests.Unit/ConsultaServiceTests.cs
+++ b/backend/MapaTributário/tests/MapaTributario.Tests.Unit/ConsultaServiceTests.cs
@@ -1,0 +1,295 @@
+using MapaTributario.API.Application.Consulta;
+using MapaTributario.API.Application.Consulta.Contracts;
+using MapaTributario.API.Domain.Entities;
+using MapaTributario.API.Domain.Interfaces;
+using Moq;
+using Shouldly;
+
+namespace MapaTributario.Tests.Unit;
+
+public class ConsultaServiceTests
+{
+    private readonly Mock<IEstadoRepository> _estadoRepository = new();
+    private readonly Mock<IMunicipioRepository> _municipioRepository = new();
+    private readonly Mock<IAliquotaRepository> _aliquotaRepository = new();
+    private readonly ConsultaService _sut;
+
+    public ConsultaServiceTests()
+    {
+        _sut = new ConsultaService(
+            _estadoRepository.Object,
+            _municipioRepository.Object,
+            _aliquotaRepository.Object);
+    }
+
+    // --- ListarEstados ---
+
+    [Fact]
+    public async Task ListarEstados_RetornaEstadosOrdenados()
+    {
+        var estados = new List<Estado>
+        {
+            Estado.Create("MG", "Minas Gerais", "SE"),
+            Estado.Create("SP", "São Paulo", "SE"),
+            Estado.Create("RJ", "Rio de Janeiro", "SE")
+        };
+        _estadoRepository.Setup(r => r.GetAllAsync()).ReturnsAsync(estados);
+
+        var result = await _sut.ListarEstadosAsync();
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Count.ShouldBe(3);
+        result.Value[0].Sigla.ShouldBe("MG");
+        result.Value[0].Nome.ShouldBe("Minas Gerais");
+        result.Value[0].Regiao.ShouldBe("SE");
+    }
+
+    [Fact]
+    public async Task ListarEstados_SemEstados_RetornaListaVazia()
+    {
+        _estadoRepository.Setup(r => r.GetAllAsync()).ReturnsAsync(new List<Estado>());
+
+        var result = await _sut.ListarEstadosAsync();
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Count.ShouldBe(0);
+    }
+
+    // --- ListarMunicipiosPorUf ---
+
+    [Fact]
+    public async Task ListarMunicipiosPorUf_UfValida_RetornaMunicipios()
+    {
+        var estado = Estado.Create("SP", "São Paulo", "SE");
+        _estadoRepository.Setup(r => r.GetBySiglaAsync("SP")).ReturnsAsync(estado);
+
+        var municipios = new List<Municipio>
+        {
+            Municipio.Create("3550308", "São Paulo", "SP"),
+            Municipio.Create("3509502", "Campinas", "SP")
+        };
+        _municipioRepository.Setup(r => r.GetByUfAsync("SP")).ReturnsAsync(municipios);
+
+        var result = await _sut.ListarMunicipiosPorUfAsync("SP");
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Count.ShouldBe(2);
+        result.Value[0].CodigoIbge.ShouldBe("3550308");
+        result.Value[0].Nome.ShouldBe("São Paulo");
+        result.Value[0].SiglaEstado.ShouldBe("SP");
+    }
+
+    [Fact]
+    public async Task ListarMunicipiosPorUf_UfInvalida_RetornaFalha()
+    {
+        _estadoRepository.Setup(r => r.GetBySiglaAsync("XX")).ReturnsAsync((Estado?)null);
+
+        var result = await _sut.ListarMunicipiosPorUfAsync("XX");
+
+        result.IsFailed.ShouldBeTrue();
+        result.Errors.First().Message.ShouldContain("XX");
+        result.Errors.First().Message.ShouldContain("não encontrada");
+    }
+
+    [Fact]
+    public async Task ListarMunicipiosPorUf_UfSemMunicipios_RetornaListaVazia()
+    {
+        var estado = Estado.Create("DF", "Distrito Federal", "CO");
+        _estadoRepository.Setup(r => r.GetBySiglaAsync("DF")).ReturnsAsync(estado);
+        _municipioRepository.Setup(r => r.GetByUfAsync("DF")).ReturnsAsync(new List<Municipio>());
+
+        var result = await _sut.ListarMunicipiosPorUfAsync("DF");
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Count.ShouldBe(0);
+    }
+
+    // --- ListarAliquotasPorMunicipio ---
+
+    [Fact]
+    public async Task ListarAliquotasPorMunicipio_MunicipioValido_RetornaPaginado()
+    {
+        var municipio = Municipio.Create("3550308", "São Paulo", "SP");
+        _municipioRepository.Setup(r => r.GetByCodigoIbgeAsync("3550308")).ReturnsAsync(municipio);
+
+        var aliquotas = new List<Aliquota>
+        {
+            Aliquota.Create("3550308", "São Paulo", "010100", "01.01.00", "Análise e desenvolvimento", 2.0m, "2024-01", "NFS-e"),
+            Aliquota.Create("3550308", "São Paulo", "010200", "01.02.00", "Programação", 3.0m, "2024-01", "NFS-e")
+        };
+        _aliquotaRepository.Setup(r => r.GetByMunicipioAsync(
+            "3550308", 1, 20, null, null, null, null, null))
+            .ReturnsAsync((aliquotas as IReadOnlyList<Aliquota>, 2L));
+
+        var queryParams = new AliquotaQueryParams { Pagina = 1, TamanhoPagina = 20 };
+        var result = await _sut.ListarAliquotasPorMunicipioAsync("3550308", queryParams);
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Items.Count.ShouldBe(2);
+        result.Value.Pagina.ShouldBe(1);
+        result.Value.TamanhoPagina.ShouldBe(20);
+        result.Value.TotalItens.ShouldBe(2);
+        result.Value.TotalPaginas.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task ListarAliquotasPorMunicipio_MunicipioInexistente_RetornaFalha()
+    {
+        _municipioRepository.Setup(r => r.GetByCodigoIbgeAsync("9999999")).ReturnsAsync((Municipio?)null);
+
+        var queryParams = new AliquotaQueryParams();
+        var result = await _sut.ListarAliquotasPorMunicipioAsync("9999999", queryParams);
+
+        result.IsFailed.ShouldBeTrue();
+        result.Errors.First().Message.ShouldContain("não encontrado");
+    }
+
+    [Fact]
+    public async Task ListarAliquotasPorMunicipio_ComFiltroCodigoServico_NormalizaCodigo()
+    {
+        var municipio = Municipio.Create("3550308", "São Paulo", "SP");
+        _municipioRepository.Setup(r => r.GetByCodigoIbgeAsync("3550308")).ReturnsAsync(municipio);
+
+        var aliquotas = new List<Aliquota>
+        {
+            Aliquota.Create("3550308", "São Paulo", "010100", "01.01.00", "Análise e desenvolvimento", 2.0m, "2024-01", "NFS-e")
+        };
+        _aliquotaRepository.Setup(r => r.GetByMunicipioAsync(
+            "3550308", 1, 20, "010100", null, null, null, null))
+            .ReturnsAsync((aliquotas as IReadOnlyList<Aliquota>, 1L));
+
+        var queryParams = new AliquotaQueryParams { CodigoServico = "01.01.00" };
+        var result = await _sut.ListarAliquotasPorMunicipioAsync("3550308", queryParams);
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Items.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task ListarAliquotasPorMunicipio_CodigoServicoInvalido_RetornaFalha()
+    {
+        var municipio = Municipio.Create("3550308", "São Paulo", "SP");
+        _municipioRepository.Setup(r => r.GetByCodigoIbgeAsync("3550308")).ReturnsAsync(municipio);
+
+        var queryParams = new AliquotaQueryParams { CodigoServico = "abc" };
+        var result = await _sut.ListarAliquotasPorMunicipioAsync("3550308", queryParams);
+
+        result.IsFailed.ShouldBeTrue();
+        result.Errors.First().Message.ShouldContain("formato inválido");
+    }
+
+    [Fact]
+    public async Task ListarAliquotasPorMunicipio_Paginacao_CalculaTotalPaginas()
+    {
+        var municipio = Municipio.Create("3550308", "São Paulo", "SP");
+        _municipioRepository.Setup(r => r.GetByCodigoIbgeAsync("3550308")).ReturnsAsync(municipio);
+
+        var aliquotas = new List<Aliquota>
+        {
+            Aliquota.Create("3550308", "São Paulo", "010100", "01.01.00", "Análise", 2.0m, "2024-01", "NFS-e")
+        };
+        _aliquotaRepository.Setup(r => r.GetByMunicipioAsync(
+            "3550308", 2, 5, null, null, null, null, null))
+            .ReturnsAsync((aliquotas as IReadOnlyList<Aliquota>, 12L));
+
+        var queryParams = new AliquotaQueryParams { Pagina = 2, TamanhoPagina = 5 };
+        var result = await _sut.ListarAliquotasPorMunicipioAsync("3550308", queryParams);
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.TotalPaginas.ShouldBe(3);
+        result.Value.Pagina.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task ListarAliquotasPorMunicipio_FormataCodigo_NaResposta()
+    {
+        var municipio = Municipio.Create("3550308", "São Paulo", "SP");
+        _municipioRepository.Setup(r => r.GetByCodigoIbgeAsync("3550308")).ReturnsAsync(municipio);
+
+        var aliquotas = new List<Aliquota>
+        {
+            Aliquota.Create("3550308", "São Paulo", "010200", "01.02.00", "Programação", 3.0m, "2024-01", "NFS-e")
+        };
+        _aliquotaRepository.Setup(r => r.GetByMunicipioAsync(
+            "3550308", 1, 20, null, null, null, null, null))
+            .ReturnsAsync((aliquotas as IReadOnlyList<Aliquota>, 1L));
+
+        var queryParams = new AliquotaQueryParams();
+        var result = await _sut.ListarAliquotasPorMunicipioAsync("3550308", queryParams);
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Items[0].CodigoServicoFormatado.ShouldBe("01.02.00");
+    }
+
+    // --- ObterDetalheAliquota ---
+
+    [Fact]
+    public async Task ObterDetalheAliquota_Existente_RetornaDetalhe()
+    {
+        var municipio = Municipio.Create("3550308", "São Paulo", "SP");
+        _municipioRepository.Setup(r => r.GetByCodigoIbgeAsync("3550308")).ReturnsAsync(municipio);
+
+        var aliquota = Aliquota.Create("3550308", "São Paulo", "010100", "01.01.00", "Análise", 2.0m, "2024-01", "NFS-e");
+        _aliquotaRepository.Setup(r => r.GetDetalheAsync("3550308", "010100")).ReturnsAsync(aliquota);
+
+        var result = await _sut.ObterDetalheAliquotaAsync("3550308", "01.01.00");
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.CodigoMunicipio.ShouldBe("3550308");
+        result.Value.NomeMunicipio.ShouldBe("São Paulo");
+        result.Value.CodigoServico.ShouldBe("010100");
+        result.Value.CodigoServicoFormatado.ShouldBe("01.01.00");
+        result.Value.ValorAliquota.ShouldBe(2.0m);
+    }
+
+    [Fact]
+    public async Task ObterDetalheAliquota_MunicipioInexistente_RetornaFalha()
+    {
+        _municipioRepository.Setup(r => r.GetByCodigoIbgeAsync("9999999")).ReturnsAsync((Municipio?)null);
+
+        var result = await _sut.ObterDetalheAliquotaAsync("9999999", "01.01.00");
+
+        result.IsFailed.ShouldBeTrue();
+        result.Errors.First().Message.ShouldContain("não encontrado");
+    }
+
+    [Fact]
+    public async Task ObterDetalheAliquota_AliquotaInexistente_RetornaFalha()
+    {
+        var municipio = Municipio.Create("3550308", "São Paulo", "SP");
+        _municipioRepository.Setup(r => r.GetByCodigoIbgeAsync("3550308")).ReturnsAsync(municipio);
+        _aliquotaRepository.Setup(r => r.GetDetalheAsync("3550308", "990000")).ReturnsAsync((Aliquota?)null);
+
+        var result = await _sut.ObterDetalheAliquotaAsync("3550308", "99.00.00");
+
+        result.IsFailed.ShouldBeTrue();
+        result.Errors.First().Message.ShouldContain("não encontrada");
+    }
+
+    [Fact]
+    public async Task ObterDetalheAliquota_CodigoServicoInvalido_RetornaFalha()
+    {
+        var municipio = Municipio.Create("3550308", "São Paulo", "SP");
+        _municipioRepository.Setup(r => r.GetByCodigoIbgeAsync("3550308")).ReturnsAsync(municipio);
+
+        var result = await _sut.ObterDetalheAliquotaAsync("3550308", "abc");
+
+        result.IsFailed.ShouldBeTrue();
+        result.Errors.First().Message.ShouldContain("formato inválido");
+    }
+
+    [Fact]
+    public async Task ObterDetalheAliquota_CodigoSemPontos_Funciona()
+    {
+        var municipio = Municipio.Create("3550308", "São Paulo", "SP");
+        _municipioRepository.Setup(r => r.GetByCodigoIbgeAsync("3550308")).ReturnsAsync(municipio);
+
+        var aliquota = Aliquota.Create("3550308", "São Paulo", "010100", "01.01.00", "Análise", 2.0m, "2024-01", "NFS-e");
+        _aliquotaRepository.Setup(r => r.GetDetalheAsync("3550308", "010100")).ReturnsAsync(aliquota);
+
+        var result = await _sut.ObterDetalheAliquotaAsync("3550308", "010100");
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.CodigoServico.ShouldBe("010100");
+    }
+}

--- a/backend/MapaTributário/tests/MapaTributario.Tests.Unit/ConsultaServiceTests.cs
+++ b/backend/MapaTributário/tests/MapaTributario.Tests.Unit/ConsultaServiceTests.cs
@@ -1,5 +1,6 @@
 using MapaTributario.API.Application.Consulta;
 using MapaTributario.API.Application.Consulta.Contracts;
+using MapaTributario.API.Application.Errors;
 using MapaTributario.API.Domain.Entities;
 using MapaTributario.API.Domain.Interfaces;
 using Moq;
@@ -80,13 +81,14 @@ public class ConsultaServiceTests
     }
 
     [Fact]
-    public async Task ListarMunicipiosPorUf_UfInvalida_RetornaFalha()
+    public async Task ListarMunicipiosPorUf_UfInvalida_RetornaNotFoundError()
     {
         _estadoRepository.Setup(r => r.GetBySiglaAsync("XX")).ReturnsAsync((Estado?)null);
 
         var result = await _sut.ListarMunicipiosPorUfAsync("XX");
 
         result.IsFailed.ShouldBeTrue();
+        result.Errors.OfType<NotFoundError>().ShouldNotBeEmpty();
         result.Errors.First().Message.ShouldContain("XX");
         result.Errors.First().Message.ShouldContain("não encontrada");
     }
@@ -133,7 +135,7 @@ public class ConsultaServiceTests
     }
 
     [Fact]
-    public async Task ListarAliquotasPorMunicipio_MunicipioInexistente_RetornaFalha()
+    public async Task ListarAliquotasPorMunicipio_MunicipioInexistente_RetornaNotFoundError()
     {
         _municipioRepository.Setup(r => r.GetByCodigoIbgeAsync("9999999")).ReturnsAsync((Municipio?)null);
 
@@ -141,6 +143,7 @@ public class ConsultaServiceTests
         var result = await _sut.ListarAliquotasPorMunicipioAsync("9999999", queryParams);
 
         result.IsFailed.ShouldBeTrue();
+        result.Errors.OfType<NotFoundError>().ShouldNotBeEmpty();
         result.Errors.First().Message.ShouldContain("não encontrado");
     }
 
@@ -166,7 +169,7 @@ public class ConsultaServiceTests
     }
 
     [Fact]
-    public async Task ListarAliquotasPorMunicipio_CodigoServicoInvalido_RetornaFalha()
+    public async Task ListarAliquotasPorMunicipio_CodigoServicoInvalido_RetornaValidationError()
     {
         var municipio = Municipio.Create("3550308", "São Paulo", "SP");
         _municipioRepository.Setup(r => r.GetByCodigoIbgeAsync("3550308")).ReturnsAsync(municipio);
@@ -175,7 +178,51 @@ public class ConsultaServiceTests
         var result = await _sut.ListarAliquotasPorMunicipioAsync("3550308", queryParams);
 
         result.IsFailed.ShouldBeTrue();
+        result.Errors.OfType<ValidationError>().ShouldNotBeEmpty();
         result.Errors.First().Message.ShouldContain("formato inválido");
+    }
+
+    [Fact]
+    public async Task ListarAliquotasPorMunicipio_ComFiltroPrefixoCodigoServico_NormalizaPrefixo()
+    {
+        var municipio = Municipio.Create("3550308", "São Paulo", "SP");
+        _municipioRepository.Setup(r => r.GetByCodigoIbgeAsync("3550308")).ReturnsAsync(municipio);
+
+        var aliquotas = new List<Aliquota>
+        {
+            Aliquota.Create("3550308", "São Paulo", "010100", "01.01.00", "Análise e desenvolvimento", 2.0m, "2024-01", "NFS-e"),
+            Aliquota.Create("3550308", "São Paulo", "010200", "01.02.00", "Programação", 3.0m, "2024-01", "NFS-e")
+        };
+        _aliquotaRepository.Setup(r => r.GetByMunicipioAsync(
+            "3550308", 1, 20, "01", null, null, null, null))
+            .ReturnsAsync((aliquotas as IReadOnlyList<Aliquota>, 2L));
+
+        var queryParams = new AliquotaQueryParams { CodigoServico = "01" };
+        var result = await _sut.ListarAliquotasPorMunicipioAsync("3550308", queryParams);
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Items.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task ListarAliquotasPorMunicipio_ComFiltroPrefixo4Digitos_NormalizaPrefixo()
+    {
+        var municipio = Municipio.Create("3550308", "São Paulo", "SP");
+        _municipioRepository.Setup(r => r.GetByCodigoIbgeAsync("3550308")).ReturnsAsync(municipio);
+
+        var aliquotas = new List<Aliquota>
+        {
+            Aliquota.Create("3550308", "São Paulo", "010100", "01.01.00", "Análise e desenvolvimento", 2.0m, "2024-01", "NFS-e")
+        };
+        _aliquotaRepository.Setup(r => r.GetByMunicipioAsync(
+            "3550308", 1, 20, "0101", null, null, null, null))
+            .ReturnsAsync((aliquotas as IReadOnlyList<Aliquota>, 1L));
+
+        var queryParams = new AliquotaQueryParams { CodigoServico = "01.01" };
+        var result = await _sut.ListarAliquotasPorMunicipioAsync("3550308", queryParams);
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Items.Count.ShouldBe(1);
     }
 
     [Fact]
@@ -243,18 +290,19 @@ public class ConsultaServiceTests
     }
 
     [Fact]
-    public async Task ObterDetalheAliquota_MunicipioInexistente_RetornaFalha()
+    public async Task ObterDetalheAliquota_MunicipioInexistente_RetornaNotFoundError()
     {
         _municipioRepository.Setup(r => r.GetByCodigoIbgeAsync("9999999")).ReturnsAsync((Municipio?)null);
 
         var result = await _sut.ObterDetalheAliquotaAsync("9999999", "01.01.00");
 
         result.IsFailed.ShouldBeTrue();
+        result.Errors.OfType<NotFoundError>().ShouldNotBeEmpty();
         result.Errors.First().Message.ShouldContain("não encontrado");
     }
 
     [Fact]
-    public async Task ObterDetalheAliquota_AliquotaInexistente_RetornaFalha()
+    public async Task ObterDetalheAliquota_AliquotaInexistente_RetornaNotFoundError()
     {
         var municipio = Municipio.Create("3550308", "São Paulo", "SP");
         _municipioRepository.Setup(r => r.GetByCodigoIbgeAsync("3550308")).ReturnsAsync(municipio);
@@ -263,11 +311,12 @@ public class ConsultaServiceTests
         var result = await _sut.ObterDetalheAliquotaAsync("3550308", "99.00.00");
 
         result.IsFailed.ShouldBeTrue();
+        result.Errors.OfType<NotFoundError>().ShouldNotBeEmpty();
         result.Errors.First().Message.ShouldContain("não encontrada");
     }
 
     [Fact]
-    public async Task ObterDetalheAliquota_CodigoServicoInvalido_RetornaFalha()
+    public async Task ObterDetalheAliquota_CodigoServicoInvalido_RetornaValidationError()
     {
         var municipio = Municipio.Create("3550308", "São Paulo", "SP");
         _municipioRepository.Setup(r => r.GetByCodigoIbgeAsync("3550308")).ReturnsAsync(municipio);
@@ -275,6 +324,7 @@ public class ConsultaServiceTests
         var result = await _sut.ObterDetalheAliquotaAsync("3550308", "abc");
 
         result.IsFailed.ShouldBeTrue();
+        result.Errors.OfType<ValidationError>().ShouldNotBeEmpty();
         result.Errors.First().Message.ShouldContain("formato inválido");
     }
 

--- a/openspec/changes/full-stack-aliquotas-municipais/tasks.md
+++ b/openspec/changes/full-stack-aliquotas-municipais/tasks.md
@@ -39,17 +39,17 @@
 
 ## 4. Backend — Seed de Dados e Endpoints de Consulta
 
-- [ ] 4.1 Criar modelos de domínio: `Estado`, `Municipio`, `Servico`, `Aliquota`
-- [ ] 4.2 Criar repositórios MongoDB para cada modelo com índices compostos
-- [ ] 4.3 Criar seed de estados (27 UFs) e municípios a partir de `context/municipios.json` (5.570 registros com Id, Codigo, Nome, Uf) executável no startup
-- [ ] 4.4 Criar seed de códigos de tributação nacional (~391 códigos ii.ss.dd do portal gov.br/nfse — derivados dos 40 itens e ~197 subitens da LC 116/2003)
-- [ ] 4.5 Criar `ConsultaService` com lógica de listagem paginada e filtros
-- [ ] 4.6 Criar `ConsultaController` com endpoints: GET estados, GET municipios por UF, GET aliquotas por município, GET detalhe aliquota
-- [ ] 4.7 Criar DTOs de response para consulta (EstadoResponse, MunicipioResponse, AliquotaResponse, AliquotaDetalheResponse, PaginatedResponse)
-- [ ] 4.8 Implementar normalização de código de serviço (aceitar com/sem pontos, retornar formatado)
-- [ ] 4.9 Documentar todos os endpoints de consulta no Swagger com exemplos
-- [ ] 4.10 Escrever testes unitários para `ConsultaService` (filtros, paginação, normalização)
-- [ ] 4.11 Escrever testes de integração para `ConsultaController` (endpoints com dados seeded)
+- [x] 4.1 Criar modelos de domínio: `Estado`, `Municipio`, `Servico`, `Aliquota`
+- [x] 4.2 Criar repositórios MongoDB para cada modelo com índices compostos
+- [x] 4.3 Criar seed de estados (27 UFs) e municípios a partir de `context/municipios.json` (5.570 registros com Id, Codigo, Nome, Uf) executável no startup
+- [x] 4.4 Criar seed de códigos de tributação nacional (~391 códigos ii.ss.dd do portal gov.br/nfse — derivados dos 40 itens e ~197 subitens da LC 116/2003)
+- [x] 4.5 Criar `ConsultaService` com lógica de listagem paginada e filtros
+- [x] 4.6 Criar `ConsultaController` com endpoints: GET estados, GET municipios por UF, GET aliquotas por município, GET detalhe aliquota
+- [x] 4.7 Criar DTOs de response para consulta (EstadoResponse, MunicipioResponse, AliquotaResponse, AliquotaDetalheResponse, PaginatedResponse)
+- [x] 4.8 Implementar normalização de código de serviço (aceitar com/sem pontos, retornar formatado)
+- [x] 4.9 Documentar todos os endpoints de consulta no Swagger com exemplos
+- [x] 4.10 Escrever testes unitários para `ConsultaService` (filtros, paginação, normalização)
+- [x] 4.11 Escrever testes de integração para `ConsultaController` (endpoints com dados seeded)
 
 ## 5. Worker / Crawler
 


### PR DESCRIPTION
## Summary
- 4 MongoDB repositories (Estado, Municipio, Servico, Aliquota) with composite indices
- IBGE seed: 27 estados + 5570 municipios from context/municipios.json (idempotent)
- Service codes seed: 203 LC 116 national codes (format ii.ss.dd)
- ConsultaService with pagination, filters, FluentResults
- ConsultaController: GET estados, GET municipios/:uf, GET aliquotas (paginated+filtered), GET detalhe
- CodigoServicoNormalizer: accepts XX.XX.XX.XXX and XXXXXXXXX formats
- DTOs: EstadoResponse, MunicipioResponse, AliquotaResponse, AliquotaDetalheResponse, PaginatedResponse<T>
- FluentValidation for query params
- ConsultaServiceExtensions for DI registration

## Test Results
- 67 unit tests (44 new + 23 existing auth) — all pass
- 26 integration tests (20 new + 6 existing auth) — all pass
- 93 total — zero failures

## Test plan
- [x] GET /api/v1/estados returns 27 states sorted by name
- [x] GET /api/v1/estados/MG/municipios returns MG municipalities
- [x] GET /api/v1/estados/XX/municipios returns 404
- [x] GET /api/v1/municipios/:ibge/aliquotas with pagination
- [x] GET /api/v1/municipios/:ibge/aliquotas with filters (codigo, descricao, aliquota range)
- [x] GET /api/v1/municipios/:ibge/aliquotas/:servico returns detail
- [x] Service code normalization (dotted and numeric formats)
- [x] Auth required (401 without token)
- [x] Seed idempotent (runs once, skips on restart)
- [x] Existing auth tests still pass

Closes #4

Generated with [Claude Code](https://claude.com/claude-code)