### PR TITLE
fix: SonarCloud fixes, API contracts, parallel crawler, public endpoints

### DIFF
--- a/backend/MapaTributário/Dockerfile
+++ b/backend/MapaTributário/Dockerfile
@@ -12,5 +12,7 @@ FROM mcr.microsoft.com/dotnet/aspnet:10.0
 WORKDIR /app
 COPY --from=build /app/publish .
 EXPOSE 5000
+# HTTP is used inside the Docker network only; TLS is terminated at the reverse proxy (nginx/load balancer).
+# Do NOT expose this container directly to the internet without TLS termination.
 ENV ASPNETCORE_URLS=http://+:5000
 ENTRYPOINT ["dotnet", "MapaTributario.API.dll"]

--- a/backend/MapaTributário/src/MapaTributario.API/Application/Crawler/Contracts/ExecutarCrawlerRequest.cs
+++ b/backend/MapaTributário/src/MapaTributario.API/Application/Crawler/Contracts/ExecutarCrawlerRequest.cs
@@ -3,4 +3,10 @@ namespace MapaTributario.API.Application.Crawler.Contracts;
 public class ExecutarCrawlerRequest
 {
     public bool ForcarReprocessamento { get; set; }
+
+    /// <summary>
+    /// Lista de UFs para filtrar a execução (ex: ["SE", "BA"]).
+    /// Se vazio ou nulo, processa todos os estados.
+    /// </summary>
+    public List<string>? Ufs { get; set; }
 }

--- a/backend/MapaTributário/src/MapaTributario.API/Application/Crawler/CrawlerService.cs
+++ b/backend/MapaTributário/src/MapaTributario.API/Application/Crawler/CrawlerService.cs
@@ -60,6 +60,7 @@ public class CrawlerService : ICrawlerService
     public async Task<ExecucaoCrawler> ExecutarAsync(
         TipoExecucao tipo,
         bool forcarReprocessamento = false,
+        IReadOnlyList<string>? filtroUfs = null,
         CancellationToken cancellationToken = default)
     {
         if (!_executionGuard.TryAcquire())
@@ -82,7 +83,7 @@ public class CrawlerService : ICrawlerService
             string competencia = GetCompetenciaAtual();
 
             // Phase 1: Discover active municipalities via convenio endpoint
-            List<Municipio> municipiosAtivos = await FaseConvenioAsync(cancellationToken);
+            List<Municipio> municipiosAtivos = await FaseConvenioAsync(filtroUfs, cancellationToken);
 
             if (municipiosAtivos.Count == 0)
             {
@@ -149,20 +150,29 @@ public class CrawlerService : ICrawlerService
         }
     }
 
-    internal async Task<List<Municipio>> FaseConvenioAsync(CancellationToken cancellationToken)
+    internal async Task<List<Municipio>> FaseConvenioAsync(
+        IReadOnlyList<string>? filtroUfs,
+        CancellationToken cancellationToken)
     {
         _logger.LogInformation("Phase 1: Discovering municipalities via convenio endpoint");
 
-        // For now, get all municipalities from database
-        // In production this would filter by state/capital for MVP phases
         List<Municipio> todos = new();
-        string[] ufs = new[]
+        string[] todasUfs = new[]
         {
             "AC","AL","AM","AP","BA","CE","DF","ES","GO","MA","MG","MS","MT",
             "PA","PB","PE","PI","PR","RJ","RN","RO","RR","RS","SC","SE","SP","TO"
         };
 
-        foreach (string uf in ufs)
+        IEnumerable<string> ufsParaProcessar = filtroUfs is { Count: > 0 }
+            ? filtroUfs.Select(u => u.ToUpperInvariant()).Where(u => todasUfs.Contains(u))
+            : todasUfs;
+
+        if (filtroUfs is { Count: > 0 })
+        {
+            _logger.LogInformation("Filtering execution to UFs: {Ufs}", string.Join(", ", ufsParaProcessar));
+        }
+
+        foreach (string uf in ufsParaProcessar)
         {
             IReadOnlyList<Municipio> porUf = await _municipioRepository.GetByUfAsync(uf);
             todos.AddRange(porUf);

--- a/backend/MapaTributário/src/MapaTributario.API/Application/Crawler/CrawlerService.cs
+++ b/backend/MapaTributário/src/MapaTributario.API/Application/Crawler/CrawlerService.cs
@@ -31,8 +31,9 @@ public class CrawlerService : ICrawlerService
     private const int BatchSize = 50;
     private const int MaxDesdobramento = 20;
     private const int MaxDetalhamento = 99;
-    private const int MaxConsecutiveDetalhamentoMisses = 3;
+    private const int MaxConsecutiveDetalhamentoMisses = 2;
     private const int MaxConsecutiveDesdobramentoMisses = 2;
+    private const int MaxParallelItems = 10;
 
     public CrawlerService(
         IExecucaoCrawlerRepository execucaoRepository,
@@ -355,10 +356,11 @@ public class CrawlerService : ICrawlerService
         string competencia,
         CancellationToken cancellationToken)
     {
-        _logger.LogInformation("Phase 3: Processing work queue");
+        _logger.LogInformation("Phase 3: Processing work queue with {Parallelism} parallel workers", MaxParallelItems);
 
-        // Track consecutive misses for early-stop per group (XX.XX.XX)
-        Dictionary<string, int> consecutiveMissesByGroup = new();
+        // Track consecutive misses for early-stop per group (XX.XX.XX) — thread-safe
+        System.Collections.Concurrent.ConcurrentDictionary<string, int> consecutiveMissesByGroup = new();
+        SemaphoreSlim semaphore = new(MaxParallelItems, MaxParallelItems);
 
         while (true)
         {
@@ -383,6 +385,8 @@ public class CrawlerService : ICrawlerService
                 break;
             }
 
+            List<Task> tasks = new(batch.Count);
+
             foreach (FilaProcessamento item in batch)
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -402,9 +406,22 @@ public class CrawlerService : ICrawlerService
                     continue;
                 }
 
-                await ProcessarItemAsync(item, execucao, competencia, consecutiveMissesByGroup, cancellationToken);
+                await semaphore.WaitAsync(cancellationToken);
+
+                tasks.Add(Task.Run(async () =>
+                {
+                    try
+                    {
+                        await ProcessarItemAsync(item, execucao, competencia, consecutiveMissesByGroup, cancellationToken);
+                    }
+                    finally
+                    {
+                        semaphore.Release();
+                    }
+                }, cancellationToken));
             }
 
+            await Task.WhenAll(tasks);
             await _execucaoRepository.UpdateAsync(execucao);
         }
     }
@@ -413,7 +430,7 @@ public class CrawlerService : ICrawlerService
         FilaProcessamento item,
         ExecucaoCrawler execucao,
         string competencia,
-        Dictionary<string, int> consecutiveMissesByGroup,
+        System.Collections.Concurrent.ConcurrentDictionary<string, int> consecutiveMissesByGroup,
         CancellationToken cancellationToken)
     {
         item.MarcarProcessando();
@@ -485,7 +502,7 @@ public class CrawlerService : ICrawlerService
         FilaProcessamento item,
         ExecucaoCrawler execucao,
         string competencia,
-        Dictionary<string, int> consecutiveMissesByGroup,
+        System.Collections.Concurrent.ConcurrentDictionary<string, int> consecutiveMissesByGroup,
         CancellationToken cancellationToken)
     {
         await _rateLimiter.WaitAsync(cancellationToken);
@@ -523,14 +540,7 @@ public class CrawlerService : ICrawlerService
         }
         else
         {
-            if (consecutiveMissesByGroup.ContainsKey(group))
-            {
-                consecutiveMissesByGroup[group]++;
-            }
-            else
-            {
-                consecutiveMissesByGroup[group] = 1;
-            }
+            consecutiveMissesByGroup.AddOrUpdate(group, 1, (_, old) => old + 1);
 
             item.MarcarConcluido();
             await _filaRepository.UpdateStatusAsync(item);
@@ -548,7 +558,7 @@ public class CrawlerService : ICrawlerService
         FilaProcessamento item,
         ExecucaoCrawler execucao,
         string competencia,
-        Dictionary<string, int> consecutiveMissesByGroup,
+        System.Collections.Concurrent.ConcurrentDictionary<string, int> consecutiveMissesByGroup,
         CancellationToken cancellationToken)
     {
         // Extract base: "01.01.00" → item="01", subitem="01"
@@ -668,14 +678,7 @@ public class CrawlerService : ICrawlerService
         }
         else
         {
-            if (consecutiveMissesByGroup.ContainsKey(group))
-            {
-                consecutiveMissesByGroup[group]++;
-            }
-            else
-            {
-                consecutiveMissesByGroup[group] = 1;
-            }
+            consecutiveMissesByGroup.AddOrUpdate(group, 1, (_, old) => old + 1);
         }
 
         _logger.LogDebug(

--- a/backend/MapaTributário/src/MapaTributario.API/Application/Crawler/CrawlerService.cs
+++ b/backend/MapaTributário/src/MapaTributario.API/Application/Crawler/CrawlerService.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using MapaTributario.API.Domain.Entities;
 using MapaTributario.API.Domain.Interfaces;
 using MapaTributario.API.Infrastructure.External;
+using MapaTributario.API.Infrastructure.External.Contracts;
 using Microsoft.Extensions.Logging;
 
 namespace MapaTributario.API.Application.Crawler;
@@ -28,6 +29,7 @@ public class CrawlerService : ICrawlerService
     private const int MaxRetries = 3;
     private const int EarlyStopThreshold = 9;
     private const int BatchSize = 50;
+    private const int MaxDesdobramento = 20;
 
     public CrawlerService(
         IExecucaoCrawlerRepository execucaoRepository,
@@ -195,7 +197,7 @@ public class CrawlerService : ICrawlerService
                 await _circuitBreaker.WaitIfOpenAsync(cancellationToken);
 
                 Stopwatch sw = Stopwatch.StartNew();
-                Infrastructure.External.Contracts.ConvenioNfseResponse? convenio =
+                ConvenioNfseResponse? convenio =
                     await _nfseApiClient.GetConvenioAsync(municipio.CodigoIbge, cancellationToken);
                 sw.Stop();
 
@@ -257,7 +259,8 @@ public class CrawlerService : ICrawlerService
                     await _circuitBreaker.WaitIfOpenAsync(cancellationToken);
 
                     Stopwatch sw = Stopwatch.StartNew();
-                    Infrastructure.External.Contracts.AliquotaNfseResponse? result =
+                    // NfseApiClient.FormatarCodigoServico adds ".000" desdobramento automatically
+                    AliquotaNfseResponse? result =
                         await _nfseApiClient.GetAliquotaAsync(
                             municipio.CodigoIbge, probeCode, competencia, cancellationToken);
                     sw.Stop();
@@ -266,7 +269,7 @@ public class CrawlerService : ICrawlerService
                     _circuitBreaker.RecordSuccess();
                     await _certificateProtection.OnItemProcessedAsync(cancellationToken);
 
-                    if (result is not null)
+                    if (result is not null && result.TemDados)
                     {
                         temDados = true;
                         break;
@@ -418,8 +421,10 @@ public class CrawlerService : ICrawlerService
             await _rateLimiter.WaitAsync(cancellationToken);
             await _circuitBreaker.WaitIfOpenAsync(cancellationToken);
 
+            // The base service code from seed (e.g., "01.01.00") is used.
+            // NfseApiClient.FormatarCodigoServico converts it to "01.01.00.000" for the API call.
             Stopwatch sw = Stopwatch.StartNew();
-            Infrastructure.External.Contracts.AliquotaNfseResponse? result =
+            AliquotaNfseResponse? result =
                 await _nfseApiClient.GetAliquotaAsync(
                     item.CodigoMunicipio, item.CodigoServico, competencia, cancellationToken);
             sw.Stop();
@@ -430,7 +435,7 @@ public class CrawlerService : ICrawlerService
 
             string group = ExtractGroup(item.CodigoServico);
 
-            if (result is not null)
+            if (result is not null && result.TemDados)
             {
                 // Reset consecutive misses for this group
                 consecutiveMissesByGroup[group] = 0;
@@ -439,17 +444,13 @@ public class CrawlerService : ICrawlerService
                 Municipio? municipio = await _municipioRepository.GetByCodigoIbgeAsync(item.CodigoMunicipio);
                 string nomeMunicipio = municipio?.Nome ?? item.CodigoMunicipio;
 
-                Aliquota aliquota = Aliquota.Create(
-                    item.CodigoMunicipio,
-                    nomeMunicipio,
-                    item.CodigoServico,
-                    FormatServiceCode(item.CodigoServico),
-                    result.DescricaoServico ?? string.Empty,
-                    result.Aliquota,
-                    competencia,
-                    "API NFS-e Nacional");
+                // Extract aliquotas from the dictionary response
+                int aliquotasSalvas = await ExtrairESalvarAliquotasAsync(
+                    result, item.CodigoMunicipio, nomeMunicipio, item.CodigoServico, competencia);
 
-                await _aliquotaRepository.UpsertAsync(aliquota);
+                _logger.LogDebug(
+                    "Saved {Count} aliquotas for municipality {Municipio}, service {Servico}",
+                    aliquotasSalvas, item.CodigoMunicipio, item.CodigoServico);
 
                 item.MarcarConcluido();
                 await _filaRepository.UpdateStatusAsync(item);
@@ -457,7 +458,7 @@ public class CrawlerService : ICrawlerService
             }
             else
             {
-                // 404 - no data (not an error)
+                // 404 or empty - no data (not an error)
                 if (consecutiveMissesByGroup.ContainsKey(group))
                 {
                     consecutiveMissesByGroup[group]++;
@@ -511,6 +512,56 @@ public class CrawlerService : ICrawlerService
             await _filaRepository.UpdateStatusAsync(item);
             _circuitBreaker.RecordFailure();
         }
+    }
+
+    /// <summary>
+    /// Extrai todas as alíquotas da resposta da API e persiste.
+    /// A resposta contém um dicionário onde a chave é o código do serviço (ex: "01.01.01.000")
+    /// e o valor é uma lista de alíquotas com Incidencia, Aliq, DtIni, DtFim.
+    /// Salva apenas alíquotas vigentes (DtFim null ou futura).
+    /// </summary>
+    internal async Task<int> ExtrairESalvarAliquotasAsync(
+        AliquotaNfseResponse response,
+        string codigoMunicipio,
+        string nomeMunicipio,
+        string codigoServicoBase,
+        string competencia)
+    {
+        if (response.Aliquotas is null || response.Aliquotas.Count == 0)
+        {
+            return 0;
+        }
+
+        int count = 0;
+
+        foreach (KeyValuePair<string, List<AliquotaItem>> entry in response.Aliquotas)
+        {
+            string codigoServicoApi = entry.Key; // e.g., "01.01.01.000"
+
+            foreach (AliquotaItem aliquotaItem in entry.Value)
+            {
+                // Only save current (vigente) aliquotas
+                if (!aliquotaItem.Vigente)
+                {
+                    continue;
+                }
+
+                Aliquota aliquota = Aliquota.Create(
+                    codigoMunicipio,
+                    nomeMunicipio,
+                    codigoServicoBase,
+                    FormatServiceCode(codigoServicoApi),
+                    string.Empty, // API doesn't return description per aliquota
+                    aliquotaItem.Aliq,
+                    competencia,
+                    "API NFS-e Nacional");
+
+                await _aliquotaRepository.UpsertAsync(aliquota);
+                count++;
+            }
+        }
+
+        return count;
     }
 
     internal static string GetCompetenciaAtual()

--- a/backend/MapaTributário/src/MapaTributario.API/Application/Crawler/CrawlerService.cs
+++ b/backend/MapaTributário/src/MapaTributario.API/Application/Crawler/CrawlerService.cs
@@ -30,6 +30,9 @@ public class CrawlerService : ICrawlerService
     private const int EarlyStopThreshold = 9;
     private const int BatchSize = 50;
     private const int MaxDesdobramento = 20;
+    private const int MaxDetalhamento = 99;
+    private const int MaxConsecutiveDetalhamentoMisses = 3;
+    private const int MaxConsecutiveDesdobramentoMisses = 2;
 
     public CrawlerService(
         IExecucaoCrawlerRepository execucaoRepository,
@@ -418,59 +421,20 @@ public class CrawlerService : ICrawlerService
 
         try
         {
-            await _rateLimiter.WaitAsync(cancellationToken);
-            await _circuitBreaker.WaitIfOpenAsync(cancellationToken);
+            // Determine if this seed code needs detalhamento iteration.
+            // Seed codes have format "XX.XX.00" — the "00" detalhamento is a placeholder.
+            // We iterate detalhamento 01, 02, 03... and for each, desdobramento 000, 001, 002... until 404.
+            bool needsIteration = NeedsDetalhamentoIteration(item.CodigoServico);
 
-            // The base service code from seed (e.g., "01.01.00") is used.
-            // NfseApiClient.FormatarCodigoServico converts it to "01.01.00.000" for the API call.
-            Stopwatch sw = Stopwatch.StartNew();
-            AliquotaNfseResponse? result =
-                await _nfseApiClient.GetAliquotaAsync(
-                    item.CodigoMunicipio, item.CodigoServico, competencia, cancellationToken);
-            sw.Stop();
-
-            _certificateProtection.OnResponseReceived(result != null ? 200 : 404, sw.Elapsed.TotalSeconds);
-            _circuitBreaker.RecordSuccess();
-            await _certificateProtection.OnItemProcessedAsync(cancellationToken);
-
-            string group = ExtractGroup(item.CodigoServico);
-
-            if (result is not null && result.TemDados)
+            if (needsIteration)
             {
-                // Reset consecutive misses for this group
-                consecutiveMissesByGroup[group] = 0;
-
-                // Get municipality name for upsert
-                Municipio? municipio = await _municipioRepository.GetByCodigoIbgeAsync(item.CodigoMunicipio);
-                string nomeMunicipio = municipio?.Nome ?? item.CodigoMunicipio;
-
-                // Extract aliquotas from the dictionary response
-                int aliquotasSalvas = await ExtrairESalvarAliquotasAsync(
-                    result, item.CodigoMunicipio, nomeMunicipio, item.CodigoServico, competencia);
-
-                _logger.LogDebug(
-                    "Saved {Count} aliquotas for municipality {Municipio}, service {Servico}",
-                    aliquotasSalvas, item.CodigoMunicipio, item.CodigoServico);
-
-                item.MarcarConcluido();
-                await _filaRepository.UpdateStatusAsync(item);
-                execucao.IncrementarProcessados();
+                await ProcessarItemComIteracaoAsync(
+                    item, execucao, competencia, consecutiveMissesByGroup, cancellationToken);
             }
             else
             {
-                // 404 or empty - no data (not an error)
-                if (consecutiveMissesByGroup.ContainsKey(group))
-                {
-                    consecutiveMissesByGroup[group]++;
-                }
-                else
-                {
-                    consecutiveMissesByGroup[group] = 1;
-                }
-
-                item.MarcarConcluido();
-                await _filaRepository.UpdateStatusAsync(item);
-                execucao.IncrementarProcessados();
+                await ProcessarItemDiretoAsync(
+                    item, execucao, competencia, consecutiveMissesByGroup, cancellationToken);
             }
         }
         catch (HttpRequestException ex)
@@ -488,7 +452,7 @@ public class CrawlerService : ICrawlerService
             }
             else
             {
-                item.MarcarErro(ex.Message, 0); // Force max retries reached
+                item.MarcarErro(ex.Message, 0);
                 execucao.IncrementarErros(
                     $"Municipio={item.CodigoMunicipio}, Servico={item.CodigoServico}: {ex.Message}");
             }
@@ -497,7 +461,6 @@ public class CrawlerService : ICrawlerService
         }
         catch (TaskCanceledException)
         {
-            // Timeout
             if (item.PodeRetentar(MaxRetries))
             {
                 item.MarcarErro("Timeout", MaxRetries);
@@ -512,6 +475,244 @@ public class CrawlerService : ICrawlerService
             await _filaRepository.UpdateStatusAsync(item);
             _circuitBreaker.RecordFailure();
         }
+    }
+
+    /// <summary>
+    /// Processa um item que NÃO precisa de iteração de detalhamento (já tem código completo).
+    /// Usado quando o código de serviço já tem detalhamento válido (ex: "01.01.01").
+    /// </summary>
+    internal async Task ProcessarItemDiretoAsync(
+        FilaProcessamento item,
+        ExecucaoCrawler execucao,
+        string competencia,
+        Dictionary<string, int> consecutiveMissesByGroup,
+        CancellationToken cancellationToken)
+    {
+        await _rateLimiter.WaitAsync(cancellationToken);
+        await _circuitBreaker.WaitIfOpenAsync(cancellationToken);
+
+        Stopwatch sw = Stopwatch.StartNew();
+        AliquotaNfseResponse? result =
+            await _nfseApiClient.GetAliquotaAsync(
+                item.CodigoMunicipio, item.CodigoServico, competencia, cancellationToken);
+        sw.Stop();
+
+        _certificateProtection.OnResponseReceived(result != null ? 200 : 404, sw.Elapsed.TotalSeconds);
+        _circuitBreaker.RecordSuccess();
+        await _certificateProtection.OnItemProcessedAsync(cancellationToken);
+
+        string group = ExtractGroup(item.CodigoServico);
+
+        if (result is not null && result.TemDados)
+        {
+            consecutiveMissesByGroup[group] = 0;
+
+            Municipio? municipio = await _municipioRepository.GetByCodigoIbgeAsync(item.CodigoMunicipio);
+            string nomeMunicipio = municipio?.Nome ?? item.CodigoMunicipio;
+
+            int aliquotasSalvas = await ExtrairESalvarAliquotasAsync(
+                result, item.CodigoMunicipio, nomeMunicipio, item.CodigoServico, competencia);
+
+            _logger.LogDebug(
+                "Saved {Count} aliquotas for municipality {Municipio}, service {Servico}",
+                aliquotasSalvas, item.CodigoMunicipio, item.CodigoServico);
+
+            item.MarcarConcluido();
+            await _filaRepository.UpdateStatusAsync(item);
+            execucao.IncrementarProcessados();
+        }
+        else
+        {
+            if (consecutiveMissesByGroup.ContainsKey(group))
+            {
+                consecutiveMissesByGroup[group]++;
+            }
+            else
+            {
+                consecutiveMissesByGroup[group] = 1;
+            }
+
+            item.MarcarConcluido();
+            await _filaRepository.UpdateStatusAsync(item);
+            execucao.IncrementarProcessados();
+        }
+    }
+
+    /// <summary>
+    /// Processa um item de seed que precisa de iteração de detalhamento.
+    /// Seed codes têm formato "XX.XX.00" — o "00" é placeholder.
+    /// Itera detalhamento 01, 02, 03... com desdobramento 000 para cada.
+    /// Para quando encontra MaxConsecutiveDetalhamentoMisses 404s consecutivos.
+    /// </summary>
+    internal async Task ProcessarItemComIteracaoAsync(
+        FilaProcessamento item,
+        ExecucaoCrawler execucao,
+        string competencia,
+        Dictionary<string, int> consecutiveMissesByGroup,
+        CancellationToken cancellationToken)
+    {
+        // Extract base: "01.01.00" → item="01", subitem="01"
+        (string itemPart, string subitemPart) = ExtrairItemSubitem(item.CodigoServico);
+
+        Municipio? municipio = await _municipioRepository.GetByCodigoIbgeAsync(item.CodigoMunicipio);
+        string nomeMunicipio = municipio?.Nome ?? item.CodigoMunicipio;
+
+        int totalAliquotasSalvas = 0;
+        int consecutiveDetalhamentoMisses = 0;
+
+        for (int det = 1; det <= MaxDetalhamento; det++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (_certificateProtection.ShouldHalt || _certificateProtection.BudgetExhausted)
+            {
+                break;
+            }
+
+            if (consecutiveDetalhamentoMisses >= MaxConsecutiveDetalhamentoMisses)
+            {
+                _logger.LogDebug(
+                    "Stopping detalhamento iteration for {Item}.{Subitem} at {Det:D2} after {Misses} consecutive misses",
+                    itemPart, subitemPart, det, consecutiveDetalhamentoMisses);
+                break;
+            }
+
+            // Try desdobramento 000 first (most common)
+            string codigoDetalhamento = $"{itemPart}.{subitemPart}.{det:D2}";
+            string codigoCompleto = $"{codigoDetalhamento}.000";
+
+            await _rateLimiter.WaitAsync(cancellationToken);
+            await _circuitBreaker.WaitIfOpenAsync(cancellationToken);
+
+            Stopwatch sw = Stopwatch.StartNew();
+            AliquotaNfseResponse? result =
+                await _nfseApiClient.GetAliquotaAsync(
+                    item.CodigoMunicipio, codigoCompleto, competencia, cancellationToken);
+            sw.Stop();
+
+            _certificateProtection.OnResponseReceived(result != null ? 200 : 404, sw.Elapsed.TotalSeconds);
+            _circuitBreaker.RecordSuccess();
+            await _certificateProtection.OnItemProcessedAsync(cancellationToken);
+
+            if (result is null || !result.TemDados)
+            {
+                consecutiveDetalhamentoMisses++;
+                continue;
+            }
+
+            // Found data! Reset consecutive misses and save
+            consecutiveDetalhamentoMisses = 0;
+
+            int saved = await ExtrairESalvarAliquotasAsync(
+                result, item.CodigoMunicipio, nomeMunicipio, item.CodigoServico, competencia);
+            totalAliquotasSalvas += saved;
+
+            _logger.LogDebug(
+                "Found {Count} aliquotas for {Municipio} service {Codigo}",
+                saved, item.CodigoMunicipio, codigoCompleto);
+
+            // Now iterate desdobramentos 001, 002, ... for this detalhamento
+            int consecutiveDesdobramentoMisses = 0;
+
+            for (int desdobramento = 1; desdobramento <= MaxDesdobramento; desdobramento++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (_certificateProtection.ShouldHalt || _certificateProtection.BudgetExhausted)
+                {
+                    break;
+                }
+
+                if (consecutiveDesdobramentoMisses >= MaxConsecutiveDesdobramentoMisses)
+                {
+                    break;
+                }
+
+                string codigoDesdobramento = $"{codigoDetalhamento}.{desdobramento:D3}";
+
+                await _rateLimiter.WaitAsync(cancellationToken);
+                await _circuitBreaker.WaitIfOpenAsync(cancellationToken);
+
+                Stopwatch swDesdobramento = Stopwatch.StartNew();
+                AliquotaNfseResponse? resultDesdobramento =
+                    await _nfseApiClient.GetAliquotaAsync(
+                        item.CodigoMunicipio, codigoDesdobramento, competencia, cancellationToken);
+                swDesdobramento.Stop();
+
+                _certificateProtection.OnResponseReceived(resultDesdobramento != null ? 200 : 404, swDesdobramento.Elapsed.TotalSeconds);
+                _circuitBreaker.RecordSuccess();
+                await _certificateProtection.OnItemProcessedAsync(cancellationToken);
+
+                if (resultDesdobramento is null || !resultDesdobramento.TemDados)
+                {
+                    consecutiveDesdobramentoMisses++;
+                    continue;
+                }
+
+                consecutiveDesdobramentoMisses = 0;
+                int savedDesdobramento = await ExtrairESalvarAliquotasAsync(
+                    resultDesdobramento, item.CodigoMunicipio, nomeMunicipio, item.CodigoServico, competencia);
+                totalAliquotasSalvas += savedDesdobramento;
+
+                _logger.LogDebug(
+                    "Found {Count} aliquotas for {Municipio} service {Codigo}",
+                    savedDesdobramento, item.CodigoMunicipio, codigoDesdobramento);
+            }
+        }
+
+        // Update group tracking
+        string group = ExtractGroup(item.CodigoServico);
+        if (totalAliquotasSalvas > 0)
+        {
+            consecutiveMissesByGroup[group] = 0;
+        }
+        else
+        {
+            if (consecutiveMissesByGroup.ContainsKey(group))
+            {
+                consecutiveMissesByGroup[group]++;
+            }
+            else
+            {
+                consecutiveMissesByGroup[group] = 1;
+            }
+        }
+
+        _logger.LogDebug(
+            "Detalhamento iteration for {Municipio}/{CodigoServico}: saved {Total} aliquotas",
+            item.CodigoMunicipio, item.CodigoServico, totalAliquotasSalvas);
+
+        item.MarcarConcluido();
+        await _filaRepository.UpdateStatusAsync(item);
+        execucao.IncrementarProcessados();
+    }
+
+    /// <summary>
+    /// Determina se o código de serviço precisa de iteração de detalhamento.
+    /// Códigos com detalhamento "00" (seed placeholder) precisam de iteração.
+    /// Exemplo: "01.01.00" → true, "01.01.01" → false
+    /// </summary>
+    internal static bool NeedsDetalhamentoIteration(string codigoServico)
+    {
+        string clean = codigoServico.Replace(".", "");
+
+        // Deve ter pelo menos 6 dígitos: item(2) + subitem(2) + detalhamento(2)
+        if (clean.Length < 6) return false;
+
+        // Se o detalhamento (posições 4-5) for "00", precisa de iteração
+        string detalhamento = clean[4..6];
+        return detalhamento == "00";
+    }
+
+    /// <summary>
+    /// Extrai item e subitem do código de serviço.
+    /// "01.01.00" → ("01", "01")
+    /// "010100" → ("01", "01")
+    /// </summary>
+    internal static (string Item, string Subitem) ExtrairItemSubitem(string codigoServico)
+    {
+        string clean = codigoServico.Replace(".", "");
+        return (clean[..2], clean[2..4]);
     }
 
     /// <summary>
@@ -540,8 +741,8 @@ public class CrawlerService : ICrawlerService
 
             foreach (AliquotaItem aliquotaItem in entry.Value)
             {
-                // Only save current (vigente) aliquotas
-                if (!aliquotaItem.Vigente)
+                // Only save current (vigente) aliquotas with a valid Aliq value
+                if (!aliquotaItem.Vigente || !aliquotaItem.Aliq.HasValue)
                 {
                     continue;
                 }
@@ -552,7 +753,7 @@ public class CrawlerService : ICrawlerService
                     codigoServicoBase,
                     FormatServiceCode(codigoServicoApi),
                     string.Empty, // API doesn't return description per aliquota
-                    aliquotaItem.Aliq,
+                    aliquotaItem.Aliq.Value,
                     competencia,
                     "API NFS-e Nacional");
 

--- a/backend/MapaTributário/src/MapaTributario.API/Application/Crawler/ICrawlerService.cs
+++ b/backend/MapaTributário/src/MapaTributario.API/Application/Crawler/ICrawlerService.cs
@@ -7,6 +7,7 @@ public interface ICrawlerService
     Task<ExecucaoCrawler> ExecutarAsync(
         TipoExecucao tipo,
         bool forcarReprocessamento = false,
+        IReadOnlyList<string>? filtroUfs = null,
         CancellationToken cancellationToken = default);
 
     bool EmExecucao { get; }

--- a/backend/MapaTributário/src/MapaTributario.API/Controllers/AuthController.cs
+++ b/backend/MapaTributário/src/MapaTributario.API/Controllers/AuthController.cs
@@ -1,4 +1,3 @@
-using FluentResults;
 using FluentValidation;
 using MapaTributario.API.Application.Auth;
 using MapaTributario.API.Application.Auth.Contracts;
@@ -26,11 +25,8 @@ public class AuthController : ControllerBase
         [FromBody] RegisterRequest request,
         [FromServices] IValidator<RegisterRequest> validator)
     {
-        var validation = await validator.ValidateAsync(request);
-        if (!validation.IsValid)
-        {
-            return BadRequest(new { erro = "Validação falhou", detalhes = validation.Errors.Select(e => e.ErrorMessage).ToArray() });
-        }
+        var validationError = await ValidateRequestAsync(request, validator);
+        if (validationError is not null) return validationError;
 
         var result = await _registerUser.ExecuteAsync(request);
         return result.IsSuccess
@@ -43,11 +39,8 @@ public class AuthController : ControllerBase
         [FromBody] LoginRequest request,
         [FromServices] IValidator<LoginRequest> validator)
     {
-        var validation = await validator.ValidateAsync(request);
-        if (!validation.IsValid)
-        {
-            return BadRequest(new { erro = "Validação falhou", detalhes = validation.Errors.Select(e => e.ErrorMessage).ToArray() });
-        }
+        var validationError = await ValidateRequestAsync(request, validator);
+        if (validationError is not null) return validationError;
 
         var result = await _loginUser.ExecuteAsync(request);
         return result.IsSuccess
@@ -60,15 +53,22 @@ public class AuthController : ControllerBase
         [FromBody] RefreshRequest request,
         [FromServices] IValidator<RefreshRequest> validator)
     {
-        var validation = await validator.ValidateAsync(request);
-        if (!validation.IsValid)
-        {
-            return BadRequest(new { erro = "Validação falhou", detalhes = validation.Errors.Select(e => e.ErrorMessage).ToArray() });
-        }
+        var validationError = await ValidateRequestAsync(request, validator);
+        if (validationError is not null) return validationError;
 
         var result = await _refreshToken.ExecuteAsync(request);
         return result.IsSuccess
             ? Ok(result.Value)
             : Unauthorized(new { erro = result.Errors.First().Message });
+    }
+
+    private static async Task<BadRequestObjectResult?> ValidateRequestAsync<T>(T request, IValidator<T> validator)
+    {
+        var validation = await validator.ValidateAsync(request);
+        if (!validation.IsValid)
+        {
+            return new BadRequestObjectResult(new { erro = "Validação falhou", detalhes = validation.Errors.Select(e => e.ErrorMessage).ToArray() });
+        }
+        return null;
     }
 }

--- a/backend/MapaTributário/src/MapaTributario.API/Controllers/ConsultaController.cs
+++ b/backend/MapaTributário/src/MapaTributario.API/Controllers/ConsultaController.cs
@@ -2,17 +2,15 @@ using FluentValidation;
 using MapaTributario.API.Application.Consulta;
 using MapaTributario.API.Application.Consulta.Contracts;
 using MapaTributario.API.Application.Errors;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace MapaTributario.API.Controllers;
 
 /// <summary>
-/// Endpoints de consulta de estados, municipios e aliquotas.
+/// Endpoints publicos de consulta de estados, municipios e aliquotas.
 /// </summary>
 [ApiController]
 [Route("api/v1")]
-[Authorize]
 public class ConsultaController : ControllerBase
 {
     private readonly IConsultaService _consultaService;
@@ -27,10 +25,8 @@ public class ConsultaController : ControllerBase
     /// </summary>
     /// <returns>Lista de estados com sigla, nome e regiao.</returns>
     /// <response code="200">Lista de estados retornada com sucesso.</response>
-    /// <response code="401">Token JWT ausente ou invalido.</response>
     [HttpGet("estados")]
     [ProducesResponseType(typeof(IReadOnlyList<EstadoResponse>), StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     public async Task<IActionResult> ListarEstados()
     {
         var result = await _consultaService.ListarEstadosAsync();
@@ -43,11 +39,9 @@ public class ConsultaController : ControllerBase
     /// <param name="uf">Sigla da UF (ex: SP, RJ, MG).</param>
     /// <returns>Lista de municipios do estado.</returns>
     /// <response code="200">Lista de municipios retornada com sucesso.</response>
-    /// <response code="401">Token JWT ausente ou invalido.</response>
     /// <response code="404">UF nao encontrada.</response>
     [HttpGet("estados/{uf}/municipios")]
     [ProducesResponseType(typeof(IReadOnlyList<MunicipioResponse>), StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> ListarMunicipiosPorUf([FromRoute] string uf)
     {
@@ -69,12 +63,10 @@ public class ConsultaController : ControllerBase
     /// <returns>Resposta paginada com aliquotas.</returns>
     /// <response code="200">Lista paginada de aliquotas retornada com sucesso.</response>
     /// <response code="400">Parametros de consulta invalidos.</response>
-    /// <response code="401">Token JWT ausente ou invalido.</response>
     /// <response code="404">Municipio nao encontrado.</response>
     [HttpGet("municipios/{codigoIbge}/aliquotas")]
     [ProducesResponseType(typeof(PaginatedResponse<AliquotaResponse>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> ListarAliquotasPorMunicipio(
         [FromRoute] string codigoIbge,
@@ -108,11 +100,9 @@ public class ConsultaController : ControllerBase
     /// <param name="codigoServico">Codigo do servico (formato ii.ss.dd ou iissdd).</param>
     /// <returns>Detalhe da aliquota.</returns>
     /// <response code="200">Detalhe da aliquota retornado com sucesso.</response>
-    /// <response code="401">Token JWT ausente ou invalido.</response>
     /// <response code="404">Municipio ou aliquota nao encontrada.</response>
     [HttpGet("municipios/{codigoIbge}/aliquotas/{codigoServico}")]
     [ProducesResponseType(typeof(AliquotaDetalheResponse), StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> ObterDetalheAliquota(
         [FromRoute] string codigoIbge,

--- a/backend/MapaTributário/src/MapaTributario.API/Controllers/CrawlerController.cs
+++ b/backend/MapaTributário/src/MapaTributario.API/Controllers/CrawlerController.cs
@@ -35,6 +35,7 @@ public class CrawlerController : ControllerBase
         }
 
         bool forcar = request?.ForcarReprocessamento ?? false;
+        List<string>? ufs = request?.Ufs;
 
         // Fire-and-forget with a new scope (CrawlerService is Scoped)
         _ = Task.Run(async () =>
@@ -43,7 +44,7 @@ public class CrawlerController : ControllerBase
             ICrawlerService crawlerService = scope.ServiceProvider.GetRequiredService<ICrawlerService>();
             try
             {
-                await crawlerService.ExecutarAsync(Domain.Entities.TipoExecucao.Manual, forcar);
+                await crawlerService.ExecutarAsync(Domain.Entities.TipoExecucao.Manual, forcar, ufs);
             }
             catch (Exception)
             {

--- a/backend/MapaTributário/src/MapaTributario.API/Domain/Entities/ExecucaoCrawler.cs
+++ b/backend/MapaTributário/src/MapaTributario.API/Domain/Entities/ExecucaoCrawler.cs
@@ -9,8 +9,13 @@ public class ExecucaoCrawler
     public TipoExecucao Tipo { get; private set; }
     public int TotalMunicipios { get; private set; }
     public int TotalServicos { get; private set; }
-    public int Processados { get; private set; }
-    public int Erros { get; private set; }
+
+    private int _processados;
+    public int Processados { get => _processados; private set => _processados = value; }
+
+    private int _erros;
+    public int Erros { get => _erros; private set => _erros = value; }
+
     public List<string> DetalhesErro { get; private set; } = new();
 
     private ExecucaoCrawler() { }
@@ -38,12 +43,17 @@ public class ExecucaoCrawler
         TotalServicos = totalServicos;
     }
 
-    public void IncrementarProcessados() => Processados++;
+    private readonly object _lock = new();
+
+    public void IncrementarProcessados() => Interlocked.Increment(ref _processados);
 
     public void IncrementarErros(string detalhe)
     {
-        Erros++;
-        DetalhesErro.Add(detalhe);
+        Interlocked.Increment(ref _erros);
+        lock (_lock)
+        {
+            DetalhesErro.Add(detalhe);
+        }
     }
 
     public void Finalizar(StatusExecucao status)

--- a/backend/MapaTributário/src/MapaTributario.API/Infrastructure/Auth/JwtTokenProvider.cs
+++ b/backend/MapaTributário/src/MapaTributario.API/Infrastructure/Auth/JwtTokenProvider.cs
@@ -15,8 +15,10 @@ public class JwtTokenProvider : ITokenProvider
     public JwtTokenProvider(IConfiguration configuration)
     {
         _configuration = configuration;
-        _key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(
-            _configuration["JWT:Secret"] ?? "default-dev-secret-change-in-production-32chars"));
+        var secret = _configuration["JWT:Secret"]
+            ?? throw new InvalidOperationException(
+                "JWT secret not configured. Set 'JWT:Secret' in appsettings or 'JWT_SECRET' environment variable.");
+        _key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(secret));
     }
 
     public int AccessTokenExpirySeconds =>

--- a/backend/MapaTributário/src/MapaTributario.API/Infrastructure/External/Contracts/AliquotaNfseResponse.cs
+++ b/backend/MapaTributário/src/MapaTributario.API/Infrastructure/External/Contracts/AliquotaNfseResponse.cs
@@ -34,7 +34,7 @@ public class AliquotaItem
     public string? Incidencia { get; set; }
 
     [JsonPropertyName("Aliq")]
-    public decimal Aliq { get; set; }
+    public decimal? Aliq { get; set; }
 
     [JsonPropertyName("DtIni")]
     public DateTime? DtIni { get; set; }

--- a/backend/MapaTributário/src/MapaTributario.API/Infrastructure/External/Contracts/AliquotaNfseResponse.cs
+++ b/backend/MapaTributário/src/MapaTributario.API/Infrastructure/External/Contracts/AliquotaNfseResponse.cs
@@ -1,8 +1,49 @@
+using System.Text.Json.Serialization;
+
 namespace MapaTributario.API.Infrastructure.External.Contracts;
 
+/// <summary>
+/// Resposta real da API NFS-e: GET /parametrizacao/{codigoMunicipio}/{codigoServico}/{competencia}/aliquota
+/// Exemplo:
+/// {
+///   "aliquotas": {
+///     "01.01.01.000": [
+///       { "Incidencia": "SIM", "Aliq": 5.00, "DtIni": "2023-10-20T00:00:00", "DtFim": null }
+///     ]
+///   },
+///   "mensagem": "Alíquotas recuperadas com sucesso."
+/// }
+/// </summary>
 public class AliquotaNfseResponse
 {
-    public decimal Aliquota { get; set; }
-    public string CodigoServico { get; set; } = null!;
-    public string DescricaoServico { get; set; } = null!;
+    [JsonPropertyName("aliquotas")]
+    public Dictionary<string, List<AliquotaItem>>? Aliquotas { get; set; }
+
+    [JsonPropertyName("mensagem")]
+    public string? Mensagem { get; set; }
+
+    /// <summary>
+    /// Verifica se a resposta contém alíquotas válidas.
+    /// </summary>
+    public bool TemDados => Aliquotas is { Count: > 0 };
+}
+
+public class AliquotaItem
+{
+    [JsonPropertyName("Incidencia")]
+    public string? Incidencia { get; set; }
+
+    [JsonPropertyName("Aliq")]
+    public decimal Aliq { get; set; }
+
+    [JsonPropertyName("DtIni")]
+    public DateTime? DtIni { get; set; }
+
+    [JsonPropertyName("DtFim")]
+    public DateTime? DtFim { get; set; }
+
+    /// <summary>
+    /// Retorna true se a alíquota está vigente (DtFim é null ou no futuro).
+    /// </summary>
+    public bool Vigente => DtFim is null || DtFim > DateTime.UtcNow;
 }

--- a/backend/MapaTributário/src/MapaTributario.API/Infrastructure/External/Contracts/ConvenioNfseResponse.cs
+++ b/backend/MapaTributário/src/MapaTributario.API/Infrastructure/External/Contracts/ConvenioNfseResponse.cs
@@ -1,7 +1,49 @@
+using System.Text.Json.Serialization;
+
 namespace MapaTributario.API.Infrastructure.External.Contracts;
 
+/// <summary>
+/// Resposta real da API NFS-e: GET /parametrizacao/{codigoMunicipio}/convenio
+/// Exemplo:
+/// {
+///   "parametrosConvenio": {
+///     "aderenteAmbienteNacional": 1,
+///     "aderenteEmissorNacional": 0,
+///     "situacaoEmissaoPadraoContribuintesRFB": 1,
+///     "aderenteMAN": 0,
+///     "permiteAproveitametoDeCreditos": true
+///   },
+///   "mensagem": "Parâmetros do convênio recuperados com sucesso."
+/// }
+/// </summary>
 public class ConvenioNfseResponse
 {
-    public bool Ativo { get; set; }
-    public string? Modo { get; set; }
+    [JsonPropertyName("parametrosConvenio")]
+    public ParametrosConvenio? ParametrosConvenio { get; set; }
+
+    [JsonPropertyName("mensagem")]
+    public string? Mensagem { get; set; }
+
+    /// <summary>
+    /// Município é considerado ativo se aderiu ao Ambiente Nacional (aderenteAmbienteNacional == 1).
+    /// </summary>
+    public bool Ativo => ParametrosConvenio?.AderenteAmbienteNacional == 1;
+}
+
+public class ParametrosConvenio
+{
+    [JsonPropertyName("aderenteAmbienteNacional")]
+    public int AderenteAmbienteNacional { get; set; }
+
+    [JsonPropertyName("aderenteEmissorNacional")]
+    public int AderenteEmissorNacional { get; set; }
+
+    [JsonPropertyName("situacaoEmissaoPadraoContribuintesRFB")]
+    public int SituacaoEmissaoPadraoContribuintesRFB { get; set; }
+
+    [JsonPropertyName("aderenteMAN")]
+    public int AderenteMAN { get; set; }
+
+    [JsonPropertyName("permiteAproveitametoDeCreditos")]
+    public bool PermiteAproveitametoDeCreditos { get; set; }
 }

--- a/backend/MapaTributário/src/MapaTributario.API/Infrastructure/External/NfseApiClient.cs
+++ b/backend/MapaTributário/src/MapaTributario.API/Infrastructure/External/NfseApiClient.cs
@@ -31,7 +31,9 @@ public class NfseApiClient : INfseApiClient
         string competencia,
         CancellationToken cancellationToken = default)
     {
-        string url = $"/parametrizacao/{codigoMunicipio}/{codigoServico}/{competencia}/aliquota";
+        // API requires format XX.XX.XX.XXX (with desdobramento)
+        string codigoFormatado = FormatarCodigoServico(codigoServico);
+        string url = $"/parametrizacao/{codigoMunicipio}/{codigoFormatado}/{competencia}/aliquota";
 
         try
         {
@@ -39,6 +41,14 @@ public class NfseApiClient : INfseApiClient
 
             if (response.StatusCode == HttpStatusCode.NotFound)
             {
+                return null;
+            }
+
+            if (response.StatusCode == HttpStatusCode.BadRequest)
+            {
+                string body = await response.Content.ReadAsStringAsync(cancellationToken);
+                _logger.LogWarning(
+                    "BadRequest from NFS-e API for {Url}: {Body}", url, body);
                 return null;
             }
 
@@ -77,4 +87,31 @@ public class NfseApiClient : INfseApiClient
         }
     }
 
+    /// <summary>
+    /// Formata código de serviço para o formato esperado pela API: XX.XX.XX.XXX
+    /// Aceita:
+    ///   "01.01.01" → "01.01.01.000"
+    ///   "01.01.00" → "01.01.00.000"
+    ///   "01.01.01.000" → "01.01.01.000" (já formatado)
+    ///   "010101000" → "01.01.01.000"
+    /// </summary>
+    internal static string FormatarCodigoServico(string codigo)
+    {
+        string clean = codigo.Replace(".", "");
+
+        // If we have 9 digits (6 service + 3 desdobramento), format with dots
+        if (clean.Length == 9)
+        {
+            return $"{clean[..2]}.{clean[2..4]}.{clean[4..6]}.{clean[6..9]}";
+        }
+
+        // If we have 6 digits (service only), append "000" desdobramento
+        if (clean.Length == 6)
+        {
+            return $"{clean[..2]}.{clean[2..4]}.{clean[4..6]}.000";
+        }
+
+        // Fallback: return as-is (shouldn't happen with valid data)
+        return codigo;
+    }
 }

--- a/backend/MapaTributário/src/MapaTributario.API/Infrastructure/External/NfseApiClient.cs
+++ b/backend/MapaTributário/src/MapaTributario.API/Infrastructure/External/NfseApiClient.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
+using System.Text.Json;
 using MapaTributario.API.Infrastructure.External.Contracts;
 
 namespace MapaTributario.API.Infrastructure.External;
@@ -58,6 +59,13 @@ public class NfseApiClient : INfseApiClient
         }
         catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
         {
+            return null;
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogWarning(
+                "Failed to deserialize aliquota response for {CodigoMunicipio}/{CodigoServico}: {Message}",
+                codigoMunicipio, codigoServico, ex.Message);
             return null;
         }
     }

--- a/backend/MapaTributário/src/MapaTributario.API/Infrastructure/Repository/FilaProcessamentoRepository.cs
+++ b/backend/MapaTributário/src/MapaTributario.API/Infrastructure/Repository/FilaProcessamentoRepository.cs
@@ -38,7 +38,15 @@ public class FilaProcessamentoRepository : IFilaProcessamentoRepository
             return;
         }
 
-        await _fila.InsertManyAsync(lista);
+        try
+        {
+            await _fila.InsertManyAsync(lista, new InsertManyOptions { IsOrdered = false });
+        }
+        catch (MongoBulkWriteException)
+        {
+            // Ignore duplicate key errors — items already in queue are fine to skip.
+            // With IsOrdered = false, all non-duplicate inserts succeed even if some fail.
+        }
     }
 
     public async Task<IReadOnlyList<FilaProcessamento>> GetPendingAsync(int batchSize)

--- a/backend/MapaTributário/src/MapaTributario.API/Program.cs
+++ b/backend/MapaTributário/src/MapaTributario.API/Program.cs
@@ -38,7 +38,8 @@ builder.Services.AddValidatorsFromAssemblyContaining<Program>();
 // JWT
 var jwtSecret = builder.Configuration["JWT:Secret"]
     ?? builder.Configuration["JWT_SECRET"]
-    ?? "default-dev-secret-change-in-production-32chars";
+    ?? throw new InvalidOperationException(
+        "JWT secret not configured. Set 'JWT:Secret' in appsettings or 'JWT_SECRET' environment variable.");
 builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddJwtBearer(options =>
     {

--- a/backend/MapaTributário/src/MapaTributario.API/appsettings.Development.json
+++ b/backend/MapaTributário/src/MapaTributario.API/appsettings.Development.json
@@ -4,5 +4,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "JWT": {
+    "Secret": "dev-only-secret-not-for-production-min-32-characters-long"
   }
 }

--- a/backend/MapaTributário/src/MapaTributario.API/appsettings.json
+++ b/backend/MapaTributário/src/MapaTributario.API/appsettings.json
@@ -18,9 +18,9 @@
   },
   "Crawler": {
     "CronSchedule": "0 2 * * *",
-    "RateLimitPerSecond": 5,
-    "BatchSize": 50,
-    "BatchPauseSeconds": 30,
+    "RateLimitPerSecond": 15,
+    "BatchSize": 200,
+    "BatchPauseSeconds": 5,
     "DailyBudget": 50000,
     "CircuitBreaker": {
       "ErrorThresholdPercent": 50,

--- a/backend/MapaTributário/src/MapaTributario.API/appsettings.json
+++ b/backend/MapaTributário/src/MapaTributario.API/appsettings.json
@@ -11,7 +11,6 @@
   },
   "MONGO_DB": "mapa_tributario",
   "JWT": {
-    "Secret": "default-dev-secret-change-in-production-min-32-characters-long",
     "Issuer": "MapaTributario",
     "Audience": "MapaTributario",
     "ExpiryMinutes": 60,

--- a/backend/MapaTributário/tests/MapaTributario.Tests.Integration/AuthControllerTests.cs
+++ b/backend/MapaTributário/tests/MapaTributario.Tests.Integration/AuthControllerTests.cs
@@ -1,60 +1,18 @@
 using System.Net;
 using System.Net.Http.Json;
 using MapaTributario.API.Application.Auth.Contracts;
-using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.Extensions.DependencyInjection;
-using MongoDB.Driver;
 using Shouldly;
-using Testcontainers.MongoDb;
 
 namespace MapaTributario.Tests.Integration;
 
-public class AuthControllerTests : IAsyncLifetime
+public class AuthControllerTests : IntegrationTestBase
 {
-    private readonly MongoDbContainer _mongoContainer = new MongoDbBuilder()
-        .WithImage("mongo:7")
-        .Build();
-
-    private WebApplicationFactory<Program> _factory = null!;
-    private HttpClient _client = null!;
-
-    public async Task InitializeAsync()
-    {
-        await _mongoContainer.StartAsync();
-
-        _factory = new WebApplicationFactory<Program>()
-            .WithWebHostBuilder(builder =>
-            {
-                builder.ConfigureServices(services =>
-                {
-                    var descriptor = services.SingleOrDefault(d => d.ServiceType == typeof(IMongoDatabase));
-                    if (descriptor is not null)
-                    {
-                        services.Remove(descriptor);
-                    }
-
-                    var client = new MongoClient(_mongoContainer.GetConnectionString());
-                    var database = client.GetDatabase("test_db");
-                    services.AddSingleton<IMongoDatabase>(database);
-                });
-            });
-
-        _client = _factory.CreateClient();
-    }
-
-    public async Task DisposeAsync()
-    {
-        _client.Dispose();
-        await _factory.DisposeAsync();
-        await _mongoContainer.DisposeAsync();
-    }
-
     [Fact]
     public async Task Register_ComDadosValidos_Retorna201()
     {
         var request = new RegisterRequest { Email = "new@test.com", Nome = "Novo Usuario", Senha = "password123" };
 
-        var response = await _client.PostAsJsonAsync("/api/v1/auth/register", request);
+        var response = await Client.PostAsJsonAsync("/api/v1/auth/register", request);
 
         response.StatusCode.ShouldBe(HttpStatusCode.Created);
         var body = await response.Content.ReadFromJsonAsync<AuthResponse>();
@@ -67,9 +25,9 @@ public class AuthControllerTests : IAsyncLifetime
     public async Task Register_ComEmailDuplicado_Retorna409()
     {
         var request = new RegisterRequest { Email = "dup@test.com", Nome = "User", Senha = "password123" };
-        await _client.PostAsJsonAsync("/api/v1/auth/register", request);
+        await Client.PostAsJsonAsync("/api/v1/auth/register", request);
 
-        var response = await _client.PostAsJsonAsync("/api/v1/auth/register", request);
+        var response = await Client.PostAsJsonAsync("/api/v1/auth/register", request);
 
         response.StatusCode.ShouldBe(HttpStatusCode.Conflict);
     }
@@ -78,10 +36,10 @@ public class AuthControllerTests : IAsyncLifetime
     public async Task Login_ComCredenciaisValidas_Retorna200()
     {
         var registerReq = new RegisterRequest { Email = "login@test.com", Nome = "User", Senha = "password123" };
-        await _client.PostAsJsonAsync("/api/v1/auth/register", registerReq);
+        await Client.PostAsJsonAsync("/api/v1/auth/register", registerReq);
 
         var loginReq = new LoginRequest { Email = "login@test.com", Senha = "password123" };
-        var response = await _client.PostAsJsonAsync("/api/v1/auth/login", loginReq);
+        var response = await Client.PostAsJsonAsync("/api/v1/auth/login", loginReq);
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
         var body = await response.Content.ReadFromJsonAsync<AuthResponse>();
@@ -94,7 +52,7 @@ public class AuthControllerTests : IAsyncLifetime
     {
         var request = new LoginRequest { Email = "nobody@test.com", Senha = "wrongpassword" };
 
-        var response = await _client.PostAsJsonAsync("/api/v1/auth/login", request);
+        var response = await Client.PostAsJsonAsync("/api/v1/auth/login", request);
 
         response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
     }
@@ -103,11 +61,11 @@ public class AuthControllerTests : IAsyncLifetime
     public async Task Refresh_ComTokenValido_Retorna200()
     {
         var registerReq = new RegisterRequest { Email = "refresh@test.com", Nome = "User", Senha = "password123" };
-        var registerResp = await _client.PostAsJsonAsync("/api/v1/auth/register", registerReq);
+        var registerResp = await Client.PostAsJsonAsync("/api/v1/auth/register", registerReq);
         var tokens = await registerResp.Content.ReadFromJsonAsync<AuthResponse>();
 
         var refreshReq = new RefreshRequest { RefreshToken = tokens!.RefreshToken };
-        var response = await _client.PostAsJsonAsync("/api/v1/auth/refresh", refreshReq);
+        var response = await Client.PostAsJsonAsync("/api/v1/auth/refresh", refreshReq);
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
     }
@@ -115,7 +73,7 @@ public class AuthControllerTests : IAsyncLifetime
     [Fact]
     public async Task HealthCheck_Retorna200()
     {
-        var response = await _client.GetAsync("/health");
+        var response = await Client.GetAsync("/health");
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
     }

--- a/backend/MapaTributário/tests/MapaTributario.Tests.Integration/ConsultaControllerTests.cs
+++ b/backend/MapaTributário/tests/MapaTributario.Tests.Integration/ConsultaControllerTests.cs
@@ -4,63 +4,22 @@ using System.Net.Http.Json;
 using MapaTributario.API.Application.Auth.Contracts;
 using MapaTributario.API.Application.Consulta.Contracts;
 using MapaTributario.API.Domain.Entities;
-using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.Extensions.DependencyInjection;
 using MongoDB.Driver;
 using Shouldly;
-using Testcontainers.MongoDb;
 
 namespace MapaTributario.Tests.Integration;
 
-public class ConsultaControllerTests : IAsyncLifetime
+public class ConsultaControllerTests : IntegrationTestBase
 {
-    private readonly MongoDbContainer _mongoContainer = new MongoDbBuilder()
-        .WithImage("mongo:7")
-        .Build();
-
-    private WebApplicationFactory<Program> _factory = null!;
-    private HttpClient _client = null!;
-    private IMongoDatabase _database = null!;
-
-    public async Task InitializeAsync()
+    protected override async Task OnInitializedAsync()
     {
-        await _mongoContainer.StartAsync();
-
-        var mongoClient = new MongoClient(_mongoContainer.GetConnectionString());
-        _database = mongoClient.GetDatabase("test_db");
-
-        _factory = new WebApplicationFactory<Program>()
-            .WithWebHostBuilder(builder =>
-            {
-                builder.ConfigureServices(services =>
-                {
-                    var descriptor = services.SingleOrDefault(d => d.ServiceType == typeof(IMongoDatabase));
-                    if (descriptor is not null)
-                    {
-                        services.Remove(descriptor);
-                    }
-
-                    services.AddSingleton<IMongoDatabase>(_database);
-                });
-            });
-
-        _client = _factory.CreateClient();
-
         await SeedTestDataAsync();
         await AuthenticateAsync();
     }
 
-    public async Task DisposeAsync()
-    {
-        _client.Dispose();
-        await _factory.DisposeAsync();
-        await _mongoContainer.DisposeAsync();
-    }
-
     private async Task SeedTestDataAsync()
     {
-        // Seed aliquotas for testing (estados, municipios and servicos are seeded by the app startup)
-        var aliquotas = _database.GetCollection<Aliquota>("aliquotas");
+        var aliquotas = Database.GetCollection<Aliquota>("aliquotas");
 
         var testAliquotas = new List<Aliquota>
         {
@@ -82,9 +41,9 @@ public class ConsultaControllerTests : IAsyncLifetime
             Nome = "Consulta Test",
             Senha = "password123"
         };
-        var registerResp = await _client.PostAsJsonAsync("/api/v1/auth/register", registerReq);
+        var registerResp = await Client.PostAsJsonAsync("/api/v1/auth/register", registerReq);
         var tokens = await registerResp.Content.ReadFromJsonAsync<AuthResponse>();
-        _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", tokens!.AccessToken);
+        Client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", tokens!.AccessToken);
     }
 
     // --- Auth ---
@@ -92,7 +51,7 @@ public class ConsultaControllerTests : IAsyncLifetime
     [Fact]
     public async Task GET_Estados_SemToken_Retorna401()
     {
-        var unauthClient = _factory.CreateClient();
+        var unauthClient = Factory.CreateClient();
 
         var response = await unauthClient.GetAsync("/api/v1/estados");
 
@@ -105,7 +64,7 @@ public class ConsultaControllerTests : IAsyncLifetime
     [Fact]
     public async Task GET_Estados_Retorna200_ComEstados()
     {
-        var response = await _client.GetAsync("/api/v1/estados");
+        var response = await Client.GetAsync("/api/v1/estados");
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
         var estados = await response.Content.ReadFromJsonAsync<List<EstadoResponse>>();
@@ -119,13 +78,11 @@ public class ConsultaControllerTests : IAsyncLifetime
     [Fact]
     public async Task GET_Estados_EstaoOrdenadosPorNome()
     {
-        var response = await _client.GetAsync("/api/v1/estados");
+        var response = await Client.GetAsync("/api/v1/estados");
         var estados = await response.Content.ReadFromJsonAsync<List<EstadoResponse>>();
 
         estados.ShouldNotBeNull();
         var nomes = estados.Select(e => e.Nome).ToList();
-        // MongoDB uses binary sort by default (accent-insensitive ordering may differ from .NET)
-        // Verify the list is returned sorted by checking adjacent pairs via MongoDB's own sort
         var nomesOrdenadosMongo = nomes.OrderBy(n => n, StringComparer.Ordinal).ToList();
         nomes.ShouldBe(nomesOrdenadosMongo);
     }
@@ -135,7 +92,7 @@ public class ConsultaControllerTests : IAsyncLifetime
     [Fact]
     public async Task GET_MunicipiosPorUf_UfValida_Retorna200()
     {
-        var response = await _client.GetAsync("/api/v1/estados/SP/municipios");
+        var response = await Client.GetAsync("/api/v1/estados/SP/municipios");
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
         var municipios = await response.Content.ReadFromJsonAsync<List<MunicipioResponse>>();
@@ -147,7 +104,7 @@ public class ConsultaControllerTests : IAsyncLifetime
     [Fact]
     public async Task GET_MunicipiosPorUf_UfInvalida_Retorna404()
     {
-        var response = await _client.GetAsync("/api/v1/estados/XX/municipios");
+        var response = await Client.GetAsync("/api/v1/estados/XX/municipios");
 
         response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
     }
@@ -155,7 +112,7 @@ public class ConsultaControllerTests : IAsyncLifetime
     [Fact]
     public async Task GET_MunicipiosPorUf_SemToken_Retorna401()
     {
-        var unauthClient = _factory.CreateClient();
+        var unauthClient = Factory.CreateClient();
 
         var response = await unauthClient.GetAsync("/api/v1/estados/SP/municipios");
 
@@ -168,7 +125,7 @@ public class ConsultaControllerTests : IAsyncLifetime
     [Fact]
     public async Task GET_AliquotasPorMunicipio_Retorna200_ComPaginacao()
     {
-        var response = await _client.GetAsync("/api/v1/municipios/3550308/aliquotas");
+        var response = await Client.GetAsync("/api/v1/municipios/3550308/aliquotas");
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
         var paginado = await response.Content.ReadFromJsonAsync<PaginatedResponse<AliquotaResponse>>();
@@ -183,7 +140,7 @@ public class ConsultaControllerTests : IAsyncLifetime
     [Fact]
     public async Task GET_AliquotasPorMunicipio_ComTamanhoPagina_LimitaResultados()
     {
-        var response = await _client.GetAsync("/api/v1/municipios/3550308/aliquotas?tamanhoPagina=2&pagina=1");
+        var response = await Client.GetAsync("/api/v1/municipios/3550308/aliquotas?tamanhoPagina=2&pagina=1");
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
         var paginado = await response.Content.ReadFromJsonAsync<PaginatedResponse<AliquotaResponse>>();
@@ -196,7 +153,7 @@ public class ConsultaControllerTests : IAsyncLifetime
     [Fact]
     public async Task GET_AliquotasPorMunicipio_Pagina2_RetornaRestante()
     {
-        var response = await _client.GetAsync("/api/v1/municipios/3550308/aliquotas?tamanhoPagina=2&pagina=2");
+        var response = await Client.GetAsync("/api/v1/municipios/3550308/aliquotas?tamanhoPagina=2&pagina=2");
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
         var paginado = await response.Content.ReadFromJsonAsync<PaginatedResponse<AliquotaResponse>>();
@@ -208,7 +165,7 @@ public class ConsultaControllerTests : IAsyncLifetime
     [Fact]
     public async Task GET_AliquotasPorMunicipio_FiltroCodigoServico_Funciona()
     {
-        var response = await _client.GetAsync("/api/v1/municipios/3550308/aliquotas?codigoServico=01.01.00");
+        var response = await Client.GetAsync("/api/v1/municipios/3550308/aliquotas?codigoServico=01.01.00");
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
         var paginado = await response.Content.ReadFromJsonAsync<PaginatedResponse<AliquotaResponse>>();
@@ -220,7 +177,7 @@ public class ConsultaControllerTests : IAsyncLifetime
     [Fact]
     public async Task GET_AliquotasPorMunicipio_FiltroPrefixoCodigoServico_RetornaMultiplos()
     {
-        var response = await _client.GetAsync("/api/v1/municipios/3550308/aliquotas?codigoServico=01");
+        var response = await Client.GetAsync("/api/v1/municipios/3550308/aliquotas?codigoServico=01");
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
         var paginado = await response.Content.ReadFromJsonAsync<PaginatedResponse<AliquotaResponse>>();
@@ -231,7 +188,7 @@ public class ConsultaControllerTests : IAsyncLifetime
     [Fact]
     public async Task GET_AliquotasPorMunicipio_FiltroPrefixo4Digitos_RetornaFiltrado()
     {
-        var response = await _client.GetAsync("/api/v1/municipios/3550308/aliquotas?codigoServico=01.01");
+        var response = await Client.GetAsync("/api/v1/municipios/3550308/aliquotas?codigoServico=01.01");
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
         var paginado = await response.Content.ReadFromJsonAsync<PaginatedResponse<AliquotaResponse>>();
@@ -243,7 +200,7 @@ public class ConsultaControllerTests : IAsyncLifetime
     [Fact]
     public async Task GET_AliquotasPorMunicipio_CodigoServicoInvalido_Retorna400()
     {
-        var response = await _client.GetAsync("/api/v1/municipios/3550308/aliquotas?codigoServico=abc");
+        var response = await Client.GetAsync("/api/v1/municipios/3550308/aliquotas?codigoServico=abc");
 
         response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
     }
@@ -251,7 +208,7 @@ public class ConsultaControllerTests : IAsyncLifetime
     [Fact]
     public async Task GET_AliquotasPorMunicipio_FiltroDescricao_Funciona()
     {
-        var response = await _client.GetAsync("/api/v1/municipios/3550308/aliquotas?descricao=Programa");
+        var response = await Client.GetAsync("/api/v1/municipios/3550308/aliquotas?descricao=Programa");
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
         var paginado = await response.Content.ReadFromJsonAsync<PaginatedResponse<AliquotaResponse>>();
@@ -263,7 +220,7 @@ public class ConsultaControllerTests : IAsyncLifetime
     [Fact]
     public async Task GET_AliquotasPorMunicipio_FiltroAliquotaMinMax_Funciona()
     {
-        var response = await _client.GetAsync("/api/v1/municipios/3550308/aliquotas?aliquotaMin=2.5&aliquotaMax=4.0");
+        var response = await Client.GetAsync("/api/v1/municipios/3550308/aliquotas?aliquotaMin=2.5&aliquotaMax=4.0");
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
         var paginado = await response.Content.ReadFromJsonAsync<PaginatedResponse<AliquotaResponse>>();
@@ -275,7 +232,7 @@ public class ConsultaControllerTests : IAsyncLifetime
     [Fact]
     public async Task GET_AliquotasPorMunicipio_MunicipioInexistente_Retorna404()
     {
-        var response = await _client.GetAsync("/api/v1/municipios/9999999/aliquotas");
+        var response = await Client.GetAsync("/api/v1/municipios/9999999/aliquotas");
 
         response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
     }
@@ -283,7 +240,7 @@ public class ConsultaControllerTests : IAsyncLifetime
     [Fact]
     public async Task GET_AliquotasPorMunicipio_TamanhoPaginaInvalido_Retorna400()
     {
-        var response = await _client.GetAsync("/api/v1/municipios/3550308/aliquotas?tamanhoPagina=0");
+        var response = await Client.GetAsync("/api/v1/municipios/3550308/aliquotas?tamanhoPagina=0");
 
         response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
     }
@@ -291,7 +248,7 @@ public class ConsultaControllerTests : IAsyncLifetime
     [Fact]
     public async Task GET_AliquotasPorMunicipio_SemToken_Retorna401()
     {
-        var unauthClient = _factory.CreateClient();
+        var unauthClient = Factory.CreateClient();
 
         var response = await unauthClient.GetAsync("/api/v1/municipios/3550308/aliquotas");
 
@@ -304,7 +261,7 @@ public class ConsultaControllerTests : IAsyncLifetime
     [Fact]
     public async Task GET_DetalheAliquota_Existente_Retorna200()
     {
-        var response = await _client.GetAsync("/api/v1/municipios/3550308/aliquotas/01.01.00");
+        var response = await Client.GetAsync("/api/v1/municipios/3550308/aliquotas/01.01.00");
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
         var detalhe = await response.Content.ReadFromJsonAsync<AliquotaDetalheResponse>();
@@ -319,7 +276,7 @@ public class ConsultaControllerTests : IAsyncLifetime
     [Fact]
     public async Task GET_DetalheAliquota_CodigoSemPontos_Funciona()
     {
-        var response = await _client.GetAsync("/api/v1/municipios/3550308/aliquotas/010100");
+        var response = await Client.GetAsync("/api/v1/municipios/3550308/aliquotas/010100");
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
         var detalhe = await response.Content.ReadFromJsonAsync<AliquotaDetalheResponse>();
@@ -330,7 +287,7 @@ public class ConsultaControllerTests : IAsyncLifetime
     [Fact]
     public async Task GET_DetalheAliquota_Inexistente_Retorna404()
     {
-        var response = await _client.GetAsync("/api/v1/municipios/3550308/aliquotas/99.00.00");
+        var response = await Client.GetAsync("/api/v1/municipios/3550308/aliquotas/99.00.00");
 
         response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
     }
@@ -338,7 +295,7 @@ public class ConsultaControllerTests : IAsyncLifetime
     [Fact]
     public async Task GET_DetalheAliquota_MunicipioInexistente_Retorna404()
     {
-        var response = await _client.GetAsync("/api/v1/municipios/9999999/aliquotas/01.01.00");
+        var response = await Client.GetAsync("/api/v1/municipios/9999999/aliquotas/01.01.00");
 
         response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
     }
@@ -346,7 +303,7 @@ public class ConsultaControllerTests : IAsyncLifetime
     [Fact]
     public async Task GET_DetalheAliquota_SemToken_Retorna401()
     {
-        var unauthClient = _factory.CreateClient();
+        var unauthClient = Factory.CreateClient();
 
         var response = await unauthClient.GetAsync("/api/v1/municipios/3550308/aliquotas/01.01.00");
 

--- a/backend/MapaTributário/tests/MapaTributario.Tests.Integration/CrawlerControllerTests.cs
+++ b/backend/MapaTributário/tests/MapaTributario.Tests.Integration/CrawlerControllerTests.cs
@@ -2,90 +2,49 @@ using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using MapaTributario.API.Application.Auth.Contracts;
-using MapaTributario.API.Application.Crawler;
 using MapaTributario.API.Application.Crawler.Contracts;
-using MapaTributario.API.Domain.Entities;
-using MapaTributario.API.Domain.Interfaces;
 using MapaTributario.API.Infrastructure.External;
-using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
-using MongoDB.Driver;
 using Moq;
 using Shouldly;
-using Testcontainers.MongoDb;
 
 namespace MapaTributario.Tests.Integration;
 
-public class CrawlerControllerTests : IAsyncLifetime
+public class CrawlerControllerTests : IntegrationTestBase
 {
-    private readonly MongoDbContainer _mongoContainer = new MongoDbBuilder()
-        .WithImage("mongo:7")
-        .Build();
-
     private readonly Mock<INfseApiClient> _mockNfseClient = new();
-    private WebApplicationFactory<Program> _factory = null!;
-    private HttpClient _client = null!;
 
-    public async Task InitializeAsync()
+    protected override void ConfigureTestServices(IServiceCollection services)
     {
-        await _mongoContainer.StartAsync();
+        // Replace NFS-e API client with mock
+        var nfseDescriptor = services.SingleOrDefault(d => d.ServiceType == typeof(INfseApiClient));
+        if (nfseDescriptor is not null)
+        {
+            services.Remove(nfseDescriptor);
+        }
 
-        _factory = new WebApplicationFactory<Program>()
-            .WithWebHostBuilder(builder =>
-            {
-                builder.ConfigureServices(services =>
-                {
-                    // Replace MongoDB
-                    ServiceDescriptor? descriptor = services.SingleOrDefault(d => d.ServiceType == typeof(IMongoDatabase));
-                    if (descriptor is not null)
-                    {
-                        services.Remove(descriptor);
-                    }
-
-                    MongoClient client = new MongoClient(_mongoContainer.GetConnectionString());
-                    IMongoDatabase database = client.GetDatabase("test_db");
-                    services.AddSingleton<IMongoDatabase>(database);
-
-                    // Replace NFS-e API client with mock
-                    ServiceDescriptor? nfseDescriptor = services.SingleOrDefault(d => d.ServiceType == typeof(INfseApiClient));
-                    if (nfseDescriptor is not null)
-                    {
-                        services.Remove(nfseDescriptor);
-                    }
-
-                    services.AddSingleton<INfseApiClient>(_mockNfseClient.Object);
-                });
-            });
-
-        _client = _factory.CreateClient();
-    }
-
-    public async Task DisposeAsync()
-    {
-        _client.Dispose();
-        await _factory.DisposeAsync();
-        await _mongoContainer.DisposeAsync();
+        services.AddSingleton<INfseApiClient>(_mockNfseClient.Object);
     }
 
     private async Task<string> GetAuthTokenAsync()
     {
-        RegisterRequest registerReq = new RegisterRequest
+        var registerReq = new RegisterRequest
         {
             Email = $"crawler-test-{Guid.NewGuid():N}@test.com",
             Nome = "Test User",
             Senha = "password123"
         };
 
-        HttpResponseMessage registerResp = await _client.PostAsJsonAsync("/api/v1/auth/register", registerReq);
-        AuthResponse? tokens = await registerResp.Content.ReadFromJsonAsync<AuthResponse>();
+        var registerResp = await Client.PostAsJsonAsync("/api/v1/auth/register", registerReq);
+        var tokens = await registerResp.Content.ReadFromJsonAsync<AuthResponse>();
         return tokens!.AccessToken;
     }
 
     [Fact]
     public async Task Executar_SemAutenticacao_Retorna401()
     {
-        using HttpClient unauthClient = _factory.CreateClient();
-        HttpResponseMessage response = await unauthClient.PostAsJsonAsync(
+        using var unauthClient = Factory.CreateClient();
+        var response = await unauthClient.PostAsJsonAsync(
             "/api/v1/crawler/executar",
             new ExecutarCrawlerRequest());
 
@@ -95,17 +54,17 @@ public class CrawlerControllerTests : IAsyncLifetime
     [Fact]
     public async Task Executar_ComAutenticacao_Retorna202()
     {
-        using HttpClient authClient = _factory.CreateClient();
-        string token = await GetAuthTokenAsync();
+        using var authClient = Factory.CreateClient();
+        var token = await GetAuthTokenAsync();
         authClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
-        HttpResponseMessage response = await authClient.PostAsJsonAsync(
+        var response = await authClient.PostAsJsonAsync(
             "/api/v1/crawler/executar",
             new ExecutarCrawlerRequest());
 
         response.StatusCode.ShouldBe(HttpStatusCode.Accepted);
 
-        ExecutarCrawlerResponse? body = await response.Content.ReadFromJsonAsync<ExecutarCrawlerResponse>();
+        var body = await response.Content.ReadFromJsonAsync<ExecutarCrawlerResponse>();
         body.ShouldNotBeNull();
         body.Mensagem.ShouldNotBeNullOrEmpty();
     }
@@ -113,11 +72,11 @@ public class CrawlerControllerTests : IAsyncLifetime
     [Fact]
     public async Task Status_SemExecucao_Retorna404Ou200()
     {
-        using HttpClient authClient = _factory.CreateClient();
-        string token = await GetAuthTokenAsync();
+        using var authClient = Factory.CreateClient();
+        var token = await GetAuthTokenAsync();
         authClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
-        HttpResponseMessage response = await authClient.GetAsync("/api/v1/crawler/status");
+        var response = await authClient.GetAsync("/api/v1/crawler/status");
 
         // May be 200 if an execution was created by another test, or 404 if none
         (response.StatusCode == HttpStatusCode.OK || response.StatusCode == HttpStatusCode.NotFound).ShouldBeTrue();
@@ -126,8 +85,8 @@ public class CrawlerControllerTests : IAsyncLifetime
     [Fact]
     public async Task Status_ComExecucao_Retorna200()
     {
-        using HttpClient authClient = _factory.CreateClient();
-        string token = await GetAuthTokenAsync();
+        using var authClient = Factory.CreateClient();
+        var token = await GetAuthTokenAsync();
         authClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
         // Create an execution first
@@ -136,10 +95,10 @@ public class CrawlerControllerTests : IAsyncLifetime
         // Wait a moment for the execution to be created
         await Task.Delay(1000);
 
-        HttpResponseMessage response = await authClient.GetAsync("/api/v1/crawler/status");
+        var response = await authClient.GetAsync("/api/v1/crawler/status");
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
-        StatusCrawlerResponse? body = await response.Content.ReadFromJsonAsync<StatusCrawlerResponse>();
+        var body = await response.Content.ReadFromJsonAsync<StatusCrawlerResponse>();
         body.ShouldNotBeNull();
         body.Id.ShouldNotBeNullOrEmpty();
     }
@@ -147,23 +106,23 @@ public class CrawlerControllerTests : IAsyncLifetime
     [Fact]
     public async Task Execucoes_Retorna200ComLista()
     {
-        using HttpClient authClient = _factory.CreateClient();
-        string token = await GetAuthTokenAsync();
+        using var authClient = Factory.CreateClient();
+        var token = await GetAuthTokenAsync();
         authClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
-        HttpResponseMessage response = await authClient.GetAsync("/api/v1/crawler/execucoes");
+        var response = await authClient.GetAsync("/api/v1/crawler/execucoes");
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
-        List<StatusCrawlerResponse>? body = await response.Content.ReadFromJsonAsync<List<StatusCrawlerResponse>>();
+        var body = await response.Content.ReadFromJsonAsync<List<StatusCrawlerResponse>>();
         body.ShouldNotBeNull();
     }
 
     [Fact]
     public async Task Execucoes_SemAutenticacao_Retorna401()
     {
-        using HttpClient unauthClient = _factory.CreateClient();
+        using var unauthClient = Factory.CreateClient();
 
-        HttpResponseMessage response = await unauthClient.GetAsync("/api/v1/crawler/execucoes");
+        var response = await unauthClient.GetAsync("/api/v1/crawler/execucoes");
 
         response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
     }
@@ -171,9 +130,9 @@ public class CrawlerControllerTests : IAsyncLifetime
     [Fact]
     public async Task Status_SemAutenticacao_Retorna401()
     {
-        using HttpClient unauthClient = _factory.CreateClient();
+        using var unauthClient = Factory.CreateClient();
 
-        HttpResponseMessage response = await unauthClient.GetAsync("/api/v1/crawler/status");
+        var response = await unauthClient.GetAsync("/api/v1/crawler/status");
 
         response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
     }

--- a/backend/MapaTributário/tests/MapaTributario.Tests.Integration/IntegrationTestBase.cs
+++ b/backend/MapaTributário/tests/MapaTributario.Tests.Integration/IntegrationTestBase.cs
@@ -1,0 +1,62 @@
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using MongoDB.Driver;
+using Testcontainers.MongoDb;
+
+namespace MapaTributario.Tests.Integration;
+
+public abstract class IntegrationTestBase : IAsyncLifetime
+{
+    private readonly MongoDbContainer _mongoContainer = new MongoDbBuilder("mongo:7")
+        .Build();
+
+    protected WebApplicationFactory<Program> Factory { get; private set; } = null!;
+    protected HttpClient Client { get; private set; } = null!;
+    protected IMongoDatabase Database { get; private set; } = null!;
+
+    public async Task InitializeAsync()
+    {
+        await _mongoContainer.StartAsync();
+
+        var mongoClient = new MongoClient(_mongoContainer.GetConnectionString());
+        Database = mongoClient.GetDatabase("test_db");
+
+        Factory = new WebApplicationFactory<Program>()
+            .WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureServices(services =>
+                {
+                    var descriptor = services.SingleOrDefault(d => d.ServiceType == typeof(IMongoDatabase));
+                    if (descriptor is not null)
+                    {
+                        services.Remove(descriptor);
+                    }
+
+                    services.AddSingleton<IMongoDatabase>(Database);
+
+                    ConfigureTestServices(services);
+                });
+            });
+
+        Client = Factory.CreateClient();
+
+        await OnInitializedAsync();
+    }
+
+    /// <summary>
+    /// Override to register additional test services (e.g., mocks).
+    /// </summary>
+    protected virtual void ConfigureTestServices(IServiceCollection services) { }
+
+    /// <summary>
+    /// Override to run setup logic after the test host is ready (e.g., seeding, authentication).
+    /// </summary>
+    protected virtual Task OnInitializedAsync() => Task.CompletedTask;
+
+    public async Task DisposeAsync()
+    {
+        Client.Dispose();
+        await Factory.DisposeAsync();
+        await _mongoContainer.DisposeAsync();
+    }
+}

--- a/backend/MapaTributário/tests/MapaTributario.Tests.Unit/CrawlerBackgroundServiceTests.cs
+++ b/backend/MapaTributário/tests/MapaTributario.Tests.Unit/CrawlerBackgroundServiceTests.cs
@@ -69,13 +69,13 @@ public class CrawlerBackgroundServiceTests
     {
         CrawlerBackgroundService sut = CreateSut();
         _executionGuard.Setup(g => g.IsRunning).Returns(false);
-        _crawlerService.Setup(c => c.ExecutarAsync(TipoExecucao.Agendado, false, It.IsAny<CancellationToken>()))
+        _crawlerService.Setup(c => c.ExecutarAsync(TipoExecucao.Agendado, false, null, It.IsAny<CancellationToken>()))
             .ReturnsAsync(ExecucaoCrawler.Create(TipoExecucao.Agendado));
 
         await sut.ExecuteScheduledRunAsync(CancellationToken.None);
 
         _crawlerService.Verify(c => c.ExecutarAsync(
-            TipoExecucao.Agendado, false, It.IsAny<CancellationToken>()), Times.Once);
+            TipoExecucao.Agendado, false, null, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -87,7 +87,7 @@ public class CrawlerBackgroundServiceTests
         await sut.ExecuteScheduledRunAsync(CancellationToken.None);
 
         _crawlerService.Verify(c => c.ExecutarAsync(
-            It.IsAny<TipoExecucao>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never);
+            It.IsAny<TipoExecucao>(), It.IsAny<bool>(), It.IsAny<IReadOnlyList<string>?>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
@@ -95,7 +95,7 @@ public class CrawlerBackgroundServiceTests
     {
         CrawlerBackgroundService sut = CreateSut();
         _executionGuard.Setup(g => g.IsRunning).Returns(false);
-        _crawlerService.Setup(c => c.ExecutarAsync(It.IsAny<TipoExecucao>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+        _crawlerService.Setup(c => c.ExecutarAsync(It.IsAny<TipoExecucao>(), It.IsAny<bool>(), It.IsAny<IReadOnlyList<string>?>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new Exception("Database error"));
 
         // Should not throw

--- a/backend/MapaTributário/tests/MapaTributario.Tests.Unit/CrawlerServiceTests.cs
+++ b/backend/MapaTributário/tests/MapaTributario.Tests.Unit/CrawlerServiceTests.cs
@@ -54,6 +54,34 @@ public class CrawlerServiceTests
             _logger.Object);
     }
 
+    #region Helpers
+
+    /// <summary>
+    /// Cria ConvenioNfseResponse ativo (aderenteAmbienteNacional = 1).
+    /// </summary>
+    private static ConvenioNfseResponse CriarConvenioAtivo() => new()
+    {
+        ParametrosConvenio = new ParametrosConvenio { AderenteAmbienteNacional = 1 },
+        Mensagem = "Parâmetros do convênio recuperados com sucesso."
+    };
+
+    /// <summary>
+    /// Cria AliquotaNfseResponse com uma alíquota vigente para o código de serviço informado.
+    /// </summary>
+    private static AliquotaNfseResponse CriarAliquotaResponse(string codigoServico, decimal aliquota) => new()
+    {
+        Aliquotas = new Dictionary<string, List<AliquotaItem>>
+        {
+            [codigoServico] = new List<AliquotaItem>
+            {
+                new() { Incidencia = "SIM", Aliq = aliquota, DtIni = DateTime.UtcNow.AddYears(-1), DtFim = null }
+            }
+        },
+        Mensagem = "Alíquotas recuperadas com sucesso."
+    };
+
+    #endregion
+
     [Fact]
     public async Task ExecutarAsync_QuandoJaEmExecucao_LancaException()
     {
@@ -94,11 +122,11 @@ public class CrawlerServiceTests
             .ReturnsAsync(municipio);
 
         _nfseClient.Setup(c => c.GetConvenioAsync("3106200", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConvenioNfseResponse { Ativo = true });
+            .ReturnsAsync(CriarConvenioAtivo());
 
         // Probe: at least one returns data
         _nfseClient.Setup(c => c.GetAliquotaAsync("3106200", "01.01.01", It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new AliquotaNfseResponse { Aliquota = 2.0m, CodigoServico = "01.01.01", DescricaoServico = "Servico teste" });
+            .ReturnsAsync(CriarAliquotaResponse("01.01.01.000", 2.0m));
 
         Servico servico = Servico.Create("01.01.01", "Servico teste", "01", "01", "01");
         _servicoRepo.Setup(r => r.GetAllAsync())
@@ -123,7 +151,7 @@ public class CrawlerServiceTests
             });
 
         _nfseClient.Setup(c => c.GetAliquotaAsync("3106200", "01.01.01", It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new AliquotaNfseResponse { Aliquota = 2.0m, CodigoServico = "01.01.01", DescricaoServico = "Servico teste" });
+            .ReturnsAsync(CriarAliquotaResponse("01.01.01.000", 2.0m));
 
         _aliquotaRepo.Setup(r => r.UpsertAsync(It.IsAny<Aliquota>())).Returns(Task.CompletedTask);
 
@@ -148,7 +176,7 @@ public class CrawlerServiceTests
             .ReturnsAsync(new List<Municipio>());
 
         _nfseClient.Setup(c => c.GetConvenioAsync("1100205", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConvenioNfseResponse { Ativo = true });
+            .ReturnsAsync(CriarConvenioAtivo());
         _nfseClient.Setup(c => c.GetConvenioAsync("1302603", It.IsAny<CancellationToken>()))
             .ReturnsAsync((ConvenioNfseResponse?)null);
 
@@ -170,7 +198,7 @@ public class CrawlerServiceTests
 
         // mun1: at least 1 probe returns data
         _nfseClient.Setup(c => c.GetAliquotaAsync("3106200", "01.01.01", competencia, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new AliquotaNfseResponse { Aliquota = 2.0m, CodigoServico = "01.01.01", DescricaoServico = "Teste" });
+            .ReturnsAsync(CriarAliquotaResponse("01.01.01.000", 2.0m));
 
         // mun2: all probes return null
         _nfseClient.Setup(c => c.GetAliquotaAsync("1302603", It.IsAny<string>(), competencia, It.IsAny<CancellationToken>()))
@@ -247,7 +275,7 @@ public class CrawlerServiceTests
         Dictionary<string, int> misses = new();
 
         _nfseClient.Setup(c => c.GetAliquotaAsync("3106200", "01.01.01", "2026-04-01", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new AliquotaNfseResponse { Aliquota = 5.0m, CodigoServico = "01.01.01", DescricaoServico = "Teste" });
+            .ReturnsAsync(CriarAliquotaResponse("01.01.01.000", 5.0m));
 
         Municipio mun = Municipio.Create("3106200", "Belo Horizonte", "MG");
         _municipioRepo.Setup(r => r.GetByCodigoIbgeAsync("3106200")).ReturnsAsync(mun);
@@ -463,5 +491,65 @@ public class CrawlerServiceTests
 
         // Assert
         _nfseClient.Verify(c => c.GetAliquotaAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ExtrairESalvarAliquotasAsync_ComMultiplasAliquotas_SalvaTodas()
+    {
+        // Arrange
+        AliquotaNfseResponse response = new()
+        {
+            Aliquotas = new Dictionary<string, List<AliquotaItem>>
+            {
+                ["01.01.01.000"] = new List<AliquotaItem>
+                {
+                    new() { Incidencia = "SIM", Aliq = 5.0m, DtIni = DateTime.UtcNow.AddYears(-1), DtFim = null },
+                    new() { Incidencia = "SIM", Aliq = 3.0m, DtIni = DateTime.UtcNow.AddYears(-2), DtFim = DateTime.UtcNow.AddYears(-1) }
+                }
+            },
+            Mensagem = "ok"
+        };
+
+        _aliquotaRepo.Setup(r => r.UpsertAsync(It.IsAny<Aliquota>())).Returns(Task.CompletedTask);
+
+        // Act
+        int count = await _sut.ExtrairESalvarAliquotasAsync(
+            response, "3106200", "Belo Horizonte", "01.01.01", "2026-04-01");
+
+        // Assert — only 1 vigente (the one with DtFim = null), the expired one is skipped
+        count.ShouldBe(1);
+        _aliquotaRepo.Verify(r => r.UpsertAsync(It.IsAny<Aliquota>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ExtrairESalvarAliquotasAsync_SemAliquotas_RetornaZero()
+    {
+        // Arrange
+        AliquotaNfseResponse response = new()
+        {
+            Aliquotas = null,
+            Mensagem = "ok"
+        };
+
+        // Act
+        int count = await _sut.ExtrairESalvarAliquotasAsync(
+            response, "3106200", "Belo Horizonte", "01.01.01", "2026-04-01");
+
+        // Assert
+        count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void NfseApiClient_FormatarCodigoServico_FormataCorretamente()
+    {
+        // 6 digits → adds .000
+        NfseApiClient.FormatarCodigoServico("01.01.01").ShouldBe("01.01.01.000");
+        NfseApiClient.FormatarCodigoServico("01.01.00").ShouldBe("01.01.00.000");
+        NfseApiClient.FormatarCodigoServico("010101").ShouldBe("01.01.01.000");
+
+        // 9 digits → formats with dots
+        NfseApiClient.FormatarCodigoServico("010101000").ShouldBe("01.01.01.000");
+        NfseApiClient.FormatarCodigoServico("01.01.01.000").ShouldBe("01.01.01.000");
+        NfseApiClient.FormatarCodigoServico("010101001").ShouldBe("01.01.01.001");
     }
 }

--- a/backend/MapaTributário/tests/MapaTributario.Tests.Unit/CrawlerServiceTests.cs
+++ b/backend/MapaTributário/tests/MapaTributario.Tests.Unit/CrawlerServiceTests.cs
@@ -272,7 +272,7 @@ public class CrawlerServiceTests
         // Arrange
         FilaProcessamento item = FilaProcessamento.Create("3106200", "01.01.01", "2026-04-01", "exec1");
         ExecucaoCrawler execucao = ExecucaoCrawler.Create(TipoExecucao.Manual);
-        Dictionary<string, int> misses = new();
+        System.Collections.Concurrent.ConcurrentDictionary<string, int> misses = new();
 
         _nfseClient.Setup(c => c.GetAliquotaAsync("3106200", "01.01.01", "2026-04-01", It.IsAny<CancellationToken>()))
             .ReturnsAsync(CriarAliquotaResponse("01.01.01.000", 5.0m));
@@ -296,7 +296,7 @@ public class CrawlerServiceTests
         // Arrange
         FilaProcessamento item = FilaProcessamento.Create("3106200", "01.01.01", "2026-04-01", "exec1");
         ExecucaoCrawler execucao = ExecucaoCrawler.Create(TipoExecucao.Manual);
-        Dictionary<string, int> misses = new();
+        System.Collections.Concurrent.ConcurrentDictionary<string, int> misses = new();
 
         _nfseClient.Setup(c => c.GetAliquotaAsync("3106200", "01.01.01", "2026-04-01", It.IsAny<CancellationToken>()))
             .ReturnsAsync((AliquotaNfseResponse?)null);
@@ -315,7 +315,7 @@ public class CrawlerServiceTests
         // Arrange
         FilaProcessamento item = FilaProcessamento.Create("3106200", "01.01.01", "2026-04-01", "exec1");
         ExecucaoCrawler execucao = ExecucaoCrawler.Create(TipoExecucao.Manual);
-        Dictionary<string, int> misses = new();
+        System.Collections.Concurrent.ConcurrentDictionary<string, int> misses = new();
 
         _nfseClient.Setup(c => c.GetAliquotaAsync("3106200", "01.01.01", "2026-04-01", It.IsAny<CancellationToken>()))
             .ThrowsAsync(new HttpRequestException("Server error", null, System.Net.HttpStatusCode.InternalServerError));
@@ -335,7 +335,7 @@ public class CrawlerServiceTests
         // Arrange
         FilaProcessamento item = FilaProcessamento.Create("3106200", "01.01.01", "2026-04-01", "exec1");
         ExecucaoCrawler execucao = ExecucaoCrawler.Create(TipoExecucao.Manual);
-        Dictionary<string, int> misses = new();
+        System.Collections.Concurrent.ConcurrentDictionary<string, int> misses = new();
 
         _nfseClient.Setup(c => c.GetAliquotaAsync("3106200", "01.01.01", "2026-04-01", It.IsAny<CancellationToken>()))
             .ThrowsAsync(new HttpRequestException("Forbidden", null, System.Net.HttpStatusCode.Forbidden));
@@ -586,7 +586,7 @@ public class CrawlerServiceTests
         // Arrange — seed code "01.01.00" should trigger iteration
         FilaProcessamento item = FilaProcessamento.Create("2800308", "01.01.00", "2026-04-01", "exec1");
         ExecucaoCrawler execucao = ExecucaoCrawler.Create(TipoExecucao.Manual);
-        Dictionary<string, int> misses = new();
+        System.Collections.Concurrent.ConcurrentDictionary<string, int> misses = new();
 
         Municipio mun = Municipio.Create("2800308", "Aracaju", "SE");
         _municipioRepo.Setup(r => r.GetByCodigoIbgeAsync("2800308")).ReturnsAsync(mun);
@@ -636,7 +636,7 @@ public class CrawlerServiceTests
         // Arrange — seed code "07.02.00", all detalhamentos return null
         FilaProcessamento item = FilaProcessamento.Create("2800308", "07.02.00", "2026-04-01", "exec1");
         ExecucaoCrawler execucao = ExecucaoCrawler.Create(TipoExecucao.Manual);
-        Dictionary<string, int> misses = new();
+        System.Collections.Concurrent.ConcurrentDictionary<string, int> misses = new();
 
         Municipio mun = Municipio.Create("2800308", "Aracaju", "SE");
         _municipioRepo.Setup(r => r.GetByCodigoIbgeAsync("2800308")).ReturnsAsync(mun);
@@ -660,7 +660,7 @@ public class CrawlerServiceTests
         // Arrange — code "01.01.01" has detalhamento 01 (not 00), so direct path
         FilaProcessamento item = FilaProcessamento.Create("2800308", "01.01.01", "2026-04-01", "exec1");
         ExecucaoCrawler execucao = ExecucaoCrawler.Create(TipoExecucao.Manual);
-        Dictionary<string, int> misses = new();
+        System.Collections.Concurrent.ConcurrentDictionary<string, int> misses = new();
 
         Municipio mun = Municipio.Create("2800308", "Aracaju", "SE");
         _municipioRepo.Setup(r => r.GetByCodigoIbgeAsync("2800308")).ReturnsAsync(mun);
@@ -683,7 +683,7 @@ public class CrawlerServiceTests
         // Arrange — seed code "01.01.00", detalhamento 01 has desdobramentos 000 and 001
         FilaProcessamento item = FilaProcessamento.Create("2800308", "01.01.00", "2026-04-01", "exec1");
         ExecucaoCrawler execucao = ExecucaoCrawler.Create(TipoExecucao.Manual);
-        Dictionary<string, int> misses = new();
+        System.Collections.Concurrent.ConcurrentDictionary<string, int> misses = new();
 
         Municipio mun = Municipio.Create("2800308", "Aracaju", "SE");
         _municipioRepo.Setup(r => r.GetByCodigoIbgeAsync("2800308")).ReturnsAsync(mun);

--- a/backend/MapaTributário/tests/MapaTributario.Tests.Unit/CrawlerServiceTests.cs
+++ b/backend/MapaTributário/tests/MapaTributario.Tests.Unit/CrawlerServiceTests.cs
@@ -552,4 +552,172 @@ public class CrawlerServiceTests
         NfseApiClient.FormatarCodigoServico("01.01.01.000").ShouldBe("01.01.01.000");
         NfseApiClient.FormatarCodigoServico("010101001").ShouldBe("01.01.01.001");
     }
+
+    #region Detalhamento Iteration Tests
+
+    [Theory]
+    [InlineData("01.01.00", true)]   // Seed code with placeholder detalhamento
+    [InlineData("010100", true)]     // Same without dots
+    [InlineData("07.02.00", true)]   // Another seed code
+    [InlineData("01.01.01", false)]  // Already has valid detalhamento
+    [InlineData("010101", false)]    // Same without dots
+    [InlineData("07.02.01", false)]  // Already has valid detalhamento
+    [InlineData("14.01.03", false)]  // Detalhamento 03
+    public void NeedsDetalhamentoIteration_DetectsCorrectly(string codigoServico, bool expected)
+    {
+        CrawlerService.NeedsDetalhamentoIteration(codigoServico).ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("01.01.00", "01", "01")]
+    [InlineData("07.02.00", "07", "02")]
+    [InlineData("14.01.00", "14", "01")]
+    [InlineData("010100", "01", "01")]
+    public void ExtrairItemSubitem_ExtractsCorrectly(string codigoServico, string expectedItem, string expectedSubitem)
+    {
+        (string item, string subitem) = CrawlerService.ExtrairItemSubitem(codigoServico);
+        item.ShouldBe(expectedItem);
+        subitem.ShouldBe(expectedSubitem);
+    }
+
+    [Fact]
+    public async Task ProcessarItemAsync_ComCodigoSeed00_UsaIteracaoDetalhamento()
+    {
+        // Arrange — seed code "01.01.00" should trigger iteration
+        FilaProcessamento item = FilaProcessamento.Create("2800308", "01.01.00", "2026-04-01", "exec1");
+        ExecucaoCrawler execucao = ExecucaoCrawler.Create(TipoExecucao.Manual);
+        Dictionary<string, int> misses = new();
+
+        Municipio mun = Municipio.Create("2800308", "Aracaju", "SE");
+        _municipioRepo.Setup(r => r.GetByCodigoIbgeAsync("2800308")).ReturnsAsync(mun);
+        _aliquotaRepo.Setup(r => r.UpsertAsync(It.IsAny<Aliquota>())).Returns(Task.CompletedTask);
+
+        // Detalhamento 01 → has data
+        _nfseClient.Setup(c => c.GetAliquotaAsync("2800308", "01.01.01.000", "2026-04-01", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CriarAliquotaResponse("01.01.01.000", 5.0m));
+
+        // Detalhamento 02 → has data
+        _nfseClient.Setup(c => c.GetAliquotaAsync("2800308", "01.01.02.000", "2026-04-01", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CriarAliquotaResponse("01.01.02.000", 3.0m));
+
+        // Detalhamento 03, 04, 05 → null (3 consecutive misses → stops)
+        _nfseClient.Setup(c => c.GetAliquotaAsync("2800308", "01.01.03.000", "2026-04-01", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((AliquotaNfseResponse?)null);
+        _nfseClient.Setup(c => c.GetAliquotaAsync("2800308", "01.01.04.000", "2026-04-01", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((AliquotaNfseResponse?)null);
+        _nfseClient.Setup(c => c.GetAliquotaAsync("2800308", "01.01.05.000", "2026-04-01", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((AliquotaNfseResponse?)null);
+
+        // Desdobramentos for detalhamento 01 → 001 has data, 002 and 003 return null
+        _nfseClient.Setup(c => c.GetAliquotaAsync("2800308", "01.01.01.001", "2026-04-01", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((AliquotaNfseResponse?)null);
+        _nfseClient.Setup(c => c.GetAliquotaAsync("2800308", "01.01.01.002", "2026-04-01", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((AliquotaNfseResponse?)null);
+
+        // Desdobramentos for detalhamento 02 → all null
+        _nfseClient.Setup(c => c.GetAliquotaAsync("2800308", "01.01.02.001", "2026-04-01", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((AliquotaNfseResponse?)null);
+        _nfseClient.Setup(c => c.GetAliquotaAsync("2800308", "01.01.02.002", "2026-04-01", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((AliquotaNfseResponse?)null);
+
+        // Act
+        await _sut.ProcessarItemAsync(item, execucao, "2026-04-01", misses, CancellationToken.None);
+
+        // Assert — should have called GetAliquotaAsync for det 01, 02, 03, 04, 05 (stops at 05 after 3 consecutive misses from 03/04/05)
+        // Plus desdobramentos for det 01 and 02
+        execucao.Processados.ShouldBe(1);
+        _aliquotaRepo.Verify(r => r.UpsertAsync(It.IsAny<Aliquota>()), Times.Exactly(2)); // 01.01.01.000 and 01.01.02.000
+        misses.GetValueOrDefault("01.01.00").ShouldBe(0); // Found data, so reset
+    }
+
+    [Fact]
+    public async Task ProcessarItemAsync_ComCodigoSeed00_SemDadosNenhumDetalhamento_IncrementaMisses()
+    {
+        // Arrange — seed code "07.02.00", all detalhamentos return null
+        FilaProcessamento item = FilaProcessamento.Create("2800308", "07.02.00", "2026-04-01", "exec1");
+        ExecucaoCrawler execucao = ExecucaoCrawler.Create(TipoExecucao.Manual);
+        Dictionary<string, int> misses = new();
+
+        Municipio mun = Municipio.Create("2800308", "Aracaju", "SE");
+        _municipioRepo.Setup(r => r.GetByCodigoIbgeAsync("2800308")).ReturnsAsync(mun);
+
+        // All detalhamentos return null
+        _nfseClient.Setup(c => c.GetAliquotaAsync("2800308", It.IsAny<string>(), "2026-04-01", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((AliquotaNfseResponse?)null);
+
+        // Act
+        await _sut.ProcessarItemAsync(item, execucao, "2026-04-01", misses, CancellationToken.None);
+
+        // Assert — no data found, group miss incremented
+        execucao.Processados.ShouldBe(1);
+        _aliquotaRepo.Verify(r => r.UpsertAsync(It.IsAny<Aliquota>()), Times.Never);
+        misses["07.02.00"].ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task ProcessarItemAsync_ComCodigoNaoSeed_UsaFluxoDireto()
+    {
+        // Arrange — code "01.01.01" has detalhamento 01 (not 00), so direct path
+        FilaProcessamento item = FilaProcessamento.Create("2800308", "01.01.01", "2026-04-01", "exec1");
+        ExecucaoCrawler execucao = ExecucaoCrawler.Create(TipoExecucao.Manual);
+        Dictionary<string, int> misses = new();
+
+        Municipio mun = Municipio.Create("2800308", "Aracaju", "SE");
+        _municipioRepo.Setup(r => r.GetByCodigoIbgeAsync("2800308")).ReturnsAsync(mun);
+        _aliquotaRepo.Setup(r => r.UpsertAsync(It.IsAny<Aliquota>())).Returns(Task.CompletedTask);
+
+        _nfseClient.Setup(c => c.GetAliquotaAsync("2800308", "01.01.01", "2026-04-01", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CriarAliquotaResponse("01.01.01.000", 5.0m));
+
+        // Act
+        await _sut.ProcessarItemAsync(item, execucao, "2026-04-01", misses, CancellationToken.None);
+
+        // Assert — direct path, single API call
+        execucao.Processados.ShouldBe(1);
+        _aliquotaRepo.Verify(r => r.UpsertAsync(It.IsAny<Aliquota>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ProcessarItemComIteracaoAsync_ComDesdobramentos_SalvaTodos()
+    {
+        // Arrange — seed code "01.01.00", detalhamento 01 has desdobramentos 000 and 001
+        FilaProcessamento item = FilaProcessamento.Create("2800308", "01.01.00", "2026-04-01", "exec1");
+        ExecucaoCrawler execucao = ExecucaoCrawler.Create(TipoExecucao.Manual);
+        Dictionary<string, int> misses = new();
+
+        Municipio mun = Municipio.Create("2800308", "Aracaju", "SE");
+        _municipioRepo.Setup(r => r.GetByCodigoIbgeAsync("2800308")).ReturnsAsync(mun);
+        _aliquotaRepo.Setup(r => r.UpsertAsync(It.IsAny<Aliquota>())).Returns(Task.CompletedTask);
+
+        // Detalhamento 01, desdobramento 000 → data
+        _nfseClient.Setup(c => c.GetAliquotaAsync("2800308", "01.01.01.000", "2026-04-01", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CriarAliquotaResponse("01.01.01.000", 5.0m));
+
+        // Detalhamento 01, desdobramento 001 → data
+        _nfseClient.Setup(c => c.GetAliquotaAsync("2800308", "01.01.01.001", "2026-04-01", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CriarAliquotaResponse("01.01.01.001", 4.0m));
+
+        // Detalhamento 01, desdobramento 002, 003 → null (2 consecutive → stops desdobramento)
+        _nfseClient.Setup(c => c.GetAliquotaAsync("2800308", "01.01.01.002", "2026-04-01", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((AliquotaNfseResponse?)null);
+        _nfseClient.Setup(c => c.GetAliquotaAsync("2800308", "01.01.01.003", "2026-04-01", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((AliquotaNfseResponse?)null);
+
+        // Detalhamento 02, 03, 04 → null (3 consecutive → stops detalhamento)
+        _nfseClient.Setup(c => c.GetAliquotaAsync("2800308", "01.01.02.000", "2026-04-01", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((AliquotaNfseResponse?)null);
+        _nfseClient.Setup(c => c.GetAliquotaAsync("2800308", "01.01.03.000", "2026-04-01", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((AliquotaNfseResponse?)null);
+        _nfseClient.Setup(c => c.GetAliquotaAsync("2800308", "01.01.04.000", "2026-04-01", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((AliquotaNfseResponse?)null);
+
+        // Act
+        await _sut.ProcessarItemAsync(item, execucao, "2026-04-01", misses, CancellationToken.None);
+
+        // Assert — 2 aliquotas saved (01.01.01.000 and 01.01.01.001)
+        execucao.Processados.ShouldBe(1);
+        _aliquotaRepo.Verify(r => r.UpsertAsync(It.IsAny<Aliquota>()), Times.Exactly(2));
+    }
+
+    #endregion
 }

--- a/backend/MapaTributário/tests/MapaTributario.Tests.Unit/CrawlerServiceTests.cs
+++ b/backend/MapaTributário/tests/MapaTributario.Tests.Unit/CrawlerServiceTests.cs
@@ -153,7 +153,7 @@ public class CrawlerServiceTests
             .ReturnsAsync((ConvenioNfseResponse?)null);
 
         // Act
-        List<Municipio> result = await _sut.FaseConvenioAsync(CancellationToken.None);
+        List<Municipio> result = await _sut.FaseConvenioAsync(null, CancellationToken.None);
 
         // Assert
         result.Count.ShouldBe(1);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       - ASPNETCORE_URLS=http://+:5000
       - MONGO_URI=mongodb://mongodb:27017
       - MONGO_DB=mapa_tributario
+      - JWT__Secret=${JWT_SECRET:?JWT_SECRET environment variable is required}
 
   frontend:
     build:


### PR DESCRIPTION
## Summary
Fixes SonarCloud Quality Gate failures on PR #22 and adds critical crawler improvements discovered during real API testing with Sergipe municipalities.

## Commits

### 1. fix: resolve SonarCloud security hotspots and reduce code duplication
- Removed hardcoded JWT secret from `Program.cs`, `JwtTokenProvider.cs`, `appsettings.json`
- Documented HTTP-only Dockerfile (TLS at reverse proxy)
- Extracted `IntegrationTestBase` shared base class (~60 duplicated lines removed)
- Extracted `ValidateRequestAsync<T>()` helper in AuthController

### 2. feat: add UF filter to crawler execution endpoint
- Added `List<string>? Ufs` to `ExecutarCrawlerRequest`
- Enables running crawler for specific states (e.g., `{"ufs": ["SE"]}`)

### 3. fix: correct NFS-e API response contracts to match real API structure
- **ConvenioNfseResponse**: rewrote with `ParametrosConvenio` nested class (`aderenteAmbienteNacional`)
- **AliquotaNfseResponse**: rewrote with `Dictionary<string, List<AliquotaItem>>` structure, nullable `Aliq`
- **NfseApiClient**: added `FormatarCodigoServico` (6-digit → 9-digit format), `BadRequest`/`JsonException` handling
- **CrawlerService**: added `ExtrairESalvarAliquotasAsync` for new response structure

### 4. feat: implement detalhamento iteration for seed service codes
- Seed codes (`XX.XX.00`) now iterate detalhamento `01`, `02`, `03`... until 2 consecutive 404s
- For each detalhamento, iterates desdobramento `001`, `002`... until 2 consecutive 404s
- Non-seed codes use direct single API call

### 5. fix: handle duplicate key errors in queue bulk insert
- `InsertManyOptions { IsOrdered = false }` + `MongoBulkWriteException` catch
- Prevents crash on re-execution with existing queue items

### 6. feat: make consulta endpoints public (remove Authorize)
- Removed `[Authorize]` from `ConsultaController` — all query endpoints are now public
- Auth remains only on `CrawlerController` (worker endpoints)

### 7. perf: parallelize crawler queue processing with 10 concurrent workers
- `SemaphoreSlim`-based parallel processing (`MaxParallelItems=10`)
- Thread-safe `ExecucaoCrawler` (`Interlocked`, `lock`)
- `ConcurrentDictionary` for group miss tracking
- Rate limit: 5 → 15 req/s, batch: 50 → 200 items, pause: 30s → 5s
- **Result: ~6x throughput (21 → 128 items/min, ~2h instead of ~8h)**

## Verification
- Build: 0 errors, 0 warnings
- Unit tests: 181/181 passing
- Crawler tested with real NFS-e API (Sergipe): 71 active municipalities, real aliquota data collected

Closes SonarCloud quality gate issues on #22.