### PR TITLE
docs: resolve 5 open questions nas specs full-stack-aliquotas-municipais

### DIFF
--- a/openspec/changes/full-stack-aliquotas-municipais/design.md
+++ b/openspec/changes/full-stack-aliquotas-municipais/design.md
@@ -37,7 +37,7 @@ Este projeto é greenfield — não existe sistema anterior. A motivação é co
 **Non-Goals:**
 - SSO, OAuth2 ou integração com provedores de identidade externos
 - Edição ou cadastro de alíquotas pelo usuário (sistema é somente leitura)
-- Cobertura de todos os 5.570 municípios no MVP — iniciar com conjunto controlado
+- Cobertura de todos os 5.570 municípios no MVP — iniciar somente com 27 capitais
 - Notificações push ou real-time via WebSocket
 - Multi-tenancy ou isolamento por organização
 - Deploy em cloud ou CI/CD pipeline (foco é ambiente local dockerizado)
@@ -164,19 +164,24 @@ Nem todos os 5.570 municípios do IBGE (arquivo `context/municipios.json`) terã
 flowchart TD
     M[Município do IBGE] --> F1{Fase 1: Convênio}
     F1 -->|GET /parametrizacao/{mun}/convenio| C1{Resposta OK?}
-    C1 -->|Não| SKIP1[Marcar 'sem_convenio' — SKIP]
-    C1 -->|Sim| F2{Fase 2: Probe}
-    F2 -->|Testar 5 serviços representativos| C2{Pelo menos 1 retornou dados?}
+    C1 -->|Não| F1B{Fase 1b: CNC sem convênio}
+    F1B -->|GET /cnc/consulta/cad/{mun}| C1B{Retornou serviços?}
+    C1B -->|Não| SKIP1[Marcar 'sem_dados' — SKIP]
+    C1B -->|Sim| F3[Fase 3: Crawl dos serviços CNC]
+    C1 -->|Sim| F2{Fase 2: Descoberta CNC}
+    F2 -->|GET /cnc/consulta/cad/{mun}| C2{Retornou serviços?}
     C2 -->|Não| SKIP2[Marcar 'sem_dados_adn' — SKIP]
-    C2 -->|Sim| F3[Fase 3: Crawl completo com early-stop]
-    F3 --> DONE[Processar todos os serviços]
+    C2 -->|Sim| F3
+    F3 --> DONE[Processar serviços descobertos]
 ```
 
-**Fase 1 — Filtro por convênio:** Chama `GET /parametrizacao/{municipio}/convenio`. Se 404/erro → skip. Custo: 1 request por município.
+**Fase 1 — Verificação de convênio:** Chama `GET /parametrizacao/{municipio}/convenio`. Custo: 1 request por município. **Importante:** município sem convênio NÃO é automaticamente descartado — ainda passa pela Fase 1b de verificação CNC.
 
-**Fase 2 — Probe com serviços representativos:** Testa 5 códigos de serviço de grupos diferentes (ex: `01.01.01.001`, `07.02.01.001`, `14.01.01.001`, `17.01.01.001`, `25.01.01.001`). Se todos falharem → município marcado como "sem_dados_adn" e pulado inteiro. Custo: max 5 requests. Isso evita enfileirar centenas de serviços para um município que não tem dado algum.
+**Fase 1b — Verificação CNC para municípios sem convênio:** Se o convênio falhou (404/erro), o worker ainda tenta `GET /cnc/consulta/cad/{municipio}`. Se retornar serviços, o município entra no crawl. Somente se ambas verificações falharem o município é descartado.
 
-**Fase 3 — Crawl completo com early-stop por subdivisão:**
+**Fase 2 — Descoberta de serviços via CNC:** Para municípios com convênio, o worker chama `GET /cnc/consulta/cad/{municipio}` para obter a lista de serviços cadastrados. Isso substitui a antiga estratégia de iterar todos os ~391 códigos nacionais × complementos municipais. O CNC retorna diretamente os serviços válidos, eliminando a necessidade de probe com serviços representativos e early-stop por subdivisão.
+
+**Fase 3 — Crawl dos serviços descobertos:** O worker enfileira apenas os serviços retornados pelo CNC. Para a iteração de desdobramentos municipais (complemento `xxx`), usa early-stop agressivo: começa em `000`, avança para `001`, e se não encontrar dados já para a iteração daquele código. Isso é mais eficiente que a premissa anterior de 9 misses consecutivos.
 
 O código de serviço na NFS-e Nacional segue o formato `ii.ss.dd.xxx`:
 
@@ -193,25 +198,27 @@ No XML: `cTribNac` = `iissdd` (6 dígitos) e `cTribMun` = `xxx` (3 dígitos).
 - **40 itens** na LC 116/2003 (com lacunas: 01 a 39)
 - **~197 subitens** (LC 116 + emendas da LC 157/2016)
 - **~391 códigos de tributação nacional** (com desdobramentos — lista pública no portal gov.br/nfse)
-- **Complemento municipal (xxx)**: variável por município — é ESTE nível que precisa de early-stop
+- **Complemento municipal (xxx)**: variável por município — descoberto via CNC, com early-stop agressivo na iteração
 
-**Estratégia de iteração:** Para cada um dos ~391 códigos nacionais (`ii.ss.dd`):
-- Seed estático dos 391 códigos a partir do portal gov.br/nfse (lista pública e conhecida)
-- Para cada código nacional, iterar complementos municipais: `.001`, `.002`, `.003`...
-- Se 9 misses consecutivos (404) no complemento → parar e pular para o próximo código nacional
-- Estimativa: ~3 complementos efetivos por código em média → ~1.200 códigos reais por município
+**Estratégia de iteração (revisada com CNC):**
+- Chamar CNC para obter serviços cadastrados do município
+- Para cada serviço do CNC, consultar alíquota diretamente
+- Para desdobramentos não cobertos pelo CNC, iterar complementos: `.000`, `.001`...
+- Se `001` retornar 404 → parar imediatamente para aquele código nacional (early-stop agressivo)
+- Retry de 3 tentativas apenas em caso de erro (não 404)
 
 **Impacto na estimativa de volume:**
 
-| Cenário | Sem otimização | Com convênio + probe + early-stop |
-|---------|---------------|-----------------------------------|
-| 5.570 municípios (raw) | ~391 × 999 × 5.570 = bilhões | ~5.570 convênio + ~5.570×5 probe = ~33K |
-| ~2.000 passam probe | — | ~2.000 × 391 × ~9 tentativas = ~7M |
-| MVP (27 capitais) | — | 27 + 135 + (27 × 391 × 9) = ~95K (~5.3h a 5 req/s) |
+| Cenário | Sem otimização | Com CNC + early-stop agressivo |
+|---------|---------------|-------------------------------|
+| 5.570 municípios (raw) | ~391 × 999 × 5.570 = bilhões | ~5.570 convênio + ~5.570 CNC = ~11K |
+| ~2.000 com serviços CNC | — | ~2.000 × ~50 serviços médio = ~100K |
+| MVP (27 capitais) | — | 27 convênio + 27 CNC + ~1.350 serviços = ~1.4K (~5 min a 5 req/s) |
 
 **Seeds:**
-- **Municípios:** Arquivo `context/municipios.json` (5.570 registros com Id, Codigo IBGE, Nome, UF)
-- **Códigos de serviço:** ~391 códigos de tributação nacional do portal gov.br/nfse — seedados estaticamente
+- **Estados:** 27 UFs brasileiras (derivados do arquivo `context/municipios.json`)
+- **Municípios:** Arquivo `context/municipios.json` (5.570 registros com Id, Codigo IBGE, Nome, UF). Todos são seedados, mas o crawler no MVP processa somente capitais.
+- **Códigos de serviço:** ~391 códigos de tributação nacional do portal gov.br/nfse — seedados estaticamente. Complementados em runtime pela descoberta via endpoint CNC por município.
 
 ---
 
@@ -378,8 +385,8 @@ graph TB
 
 ### R2: Formato de código de serviço inconsistente
 **Risco:** Os arquivos Bruno mostram formatos diferentes (`01.01.01.001` vs `010301001`). O README diz LC 116/2003 com pontos.
-**Premissa:** Armazenar internamente sem pontos (numérico puro) e formatar para exibição. Normalizar na entrada tanto do worker quanto da API.
-**Mitigação:** Validação centralizada no domínio com regex que aceita ambos os formatos.
+**Decisão:** Armazenar internamente **sem pontos** (numérico puro, ex: `010101001`) para indexação e comparação simples. A API NFS-e nos endpoints de parametrização (alíquotas, histórico) usa formato com pontos — o worker normaliza para `XX.XX.XX.XXX` ao enviar. O frontend exibe com máscara (pontos). O backend aceita ambos os formatos na entrada do usuário e normaliza para sem pontos antes de persistir.
+**Mitigação:** Validação centralizada no domínio com regex que aceita ambos os formatos. Normalização bidirecional: sem pontos para storage, com pontos para API NFS-e e exibição.
 
 ### R3: Formato de competência divergente
 **Risco:** Bruno files usam data completa (`2026-01-09`), README usa `YYYYMM`.
@@ -387,12 +394,12 @@ graph TB
 **Mitigação:** Testar ambos os formatos na análise da API externa e documentar o comportamento real.
 
 ### R4: Volume de dados para crawling completo
-**Risco:** 5.570 municípios × ~600 códigos de serviço × competências = milhões de combinações possíveis.
-**Mitigação:** Iniciar com subconjunto controlado (capitais + municípios com convênio ativo). Expandir progressivamente. Worker com fila permite controle granular.
+**Risco:** 5.570 municípios × serviços variáveis × competências = grande volume de combinações possíveis.
+**Mitigação:** MVP inicia somente com as 27 capitais. Uso do endpoint CNC para descoberta de serviços por município reduz drasticamente o volume (de milhões para milhares). Worker com fila persistente permite expansão progressiva. Early-stop agressivo nos desdobramentos municipais.
 
 ### R5: Certificado PFX para API NFS-e
-**Risco:** O acesso à API requer certificado cliente. O gerenciamento do certificado em Docker precisa ser seguro.
-**Mitigação:** Montar certificado via volume ou secret do Docker. Nunca versionar o PFX (já no `.gitignore`). Documentar processo de configuração.
+**Risco:** O acesso à API requer certificado cliente. O gerenciamento do certificado precisa ser seguro e operacional.
+**Mitigação:** Certificado gerenciado via endpoint REST da API (`POST /api/v1/crawler/certificado`), restrito a usuários admin. Permite rotação sem restart do container. Nunca versionado no git (`.gitignore`). Status e validade monitoráveis via `GET /api/v1/crawler/certificado`.
 
 ### R6: Bloqueio do certificado PFX por excesso de requests
 **Risco:** A API NFS-e pode bloquear o certificado PFX se detectar volume excessivo de chamadas, causando parada total da coleta.
@@ -445,14 +452,30 @@ flowchart LR
 
 ---
 
-## Open Questions
+## Resolved Questions
 
-1. **Quais municípios incluir no seed inicial?** Premissa: 27 capitais + municípios com convênio ativo (descobertos via endpoint `/parametrizacao/{municipio}/convenio`).
+1. **Quais municípios incluir no seed inicial?**
+   - **Resposta:** Seed de todos os estados brasileiros (27 UFs) e somente capitais inicialmente.
+   - **Impacto:** O worker no MVP processa apenas as 27 capitais. A tabela `municipios` contém todos os 5.570 municípios do IBGE para referência, mas o crawler só enfileira capitais. Expansão para outros municípios será feita em fases futuras.
 
-2. **A API NFS-e tem rate limit documentado?** Não encontrado nos Bruno files. Premissa conservadora: max 10 req/s.
+2. **A API NFS-e tem rate limit documentado?**
+   - **Resposta:** Não há rate limit documentado. A estratégia adotada é:
+     - Para iteração de desdobramentos municipais (complemento `xxx`): começar pelo `000`; quando avançar para o `001` e não encontrar dados, já parar a iteração daquele código nacional. Ou seja, early-stop imediato após primeiro miss no complemento.
+     - Para busca de serviços: se não encontrar dados para um serviço, avançar para o próximo imediatamente. Em caso de erro (não 404), aplicar rate de 3 retries antes de desistir.
+   - **Impacto:** O early-stop do desdobramento é mais agressivo do que os 9 misses consecutivos da premissa original. Isso reduz drasticamente o volume de requests. O rate limit conservador de 5 req/s é mantido como proteção geral.
 
-3. **O endpoint CNC (`/cnc/consulta/cad/{municipio}`) retorna lista de serviços do município?** Se sim, pode ser usado para descobrir serviços válidos por município ao invés de iterar toda a tabela LC 116. Necessita teste real.
+3. **O endpoint CNC (`/cnc/consulta/cad/{municipio}`) retorna lista de serviços do município?**
+   - **Resposta:** Sim. Usar o endpoint CNC para descobrir serviços válidos por município em vez de iterar a tabela LC 116 inteira.
+   - **Impacto:** O worker DEVE chamar `GET /cnc/consulta/cad/{municipio}` antes de enfileirar serviços. Isso substitui a estratégia de iterar todos os ~391 códigos nacionais × complementos municipais. O CNC retorna diretamente quais serviços o município tem cadastrados, eliminando a necessidade de probe e early-stop para descoberta. A fase de probe (testar 5 serviços representativos) pode ser simplificada ou removida, já que o CNC já indica se o município tem serviços cadastrados.
 
-4. **Qual o comportamento da API quando município não tem convênio?** Premissa: retorna 404 ou resposta vazia. O worker deve tratar ambos os cenários.
+4. **Qual o comportamento da API quando município não tem convênio?**
+   - **Resposta:** Verificar na consulta — é possível que mesmo sem convênio formal, o município tenha dados disponíveis na API.
+   - **Impacto:** O worker NÃO deve descartar automaticamente municípios sem convênio. Em vez disso: (1) tentar o endpoint de convênio primeiro, (2) se não encontrar convênio, ainda assim tentar o endpoint CNC para verificar se há serviços cadastrados, (3) somente pular o município se ambas as verificações falharem. Isso garante cobertura de municípios que podem ter aderido recentemente ou que têm dados sem convênio formal registrado.
 
-5. **O certificado PFX será fornecido pela equipe ou existe um de desenvolvimento/sandbox?** Premissa: será fornecido e montado via volume Docker.
+5. **O certificado PFX será fornecido pela equipe ou existe um de desenvolvimento/sandbox?**
+   - **Resposta:** O certificado será gerenciado via endpoint de upload na API, restrito a usuários admin.
+   - **Impacto:** Não será montado via volume Docker. O backend expõe endpoints REST para gestão do certificado:
+     - `POST /api/v1/crawler/certificado` — upload do PFX (multipart/form-data, requer role admin)
+     - `GET /api/v1/crawler/certificado` — status do certificado (validade, thumbprint)
+     - `DELETE /api/v1/crawler/certificado` — remoção do certificado
+   - Vantagens: rotação sem restart do container, auditoria de uploads, monitoramento de validade via API.

--- a/openspec/changes/full-stack-aliquotas-municipais/docs/worker-strategy.md
+++ b/openspec/changes/full-stack-aliquotas-municipais/docs/worker-strategy.md
@@ -108,15 +108,20 @@ graph TB
 
 ## Descoberta de Municipios Ativos
 
-Nem todos os 5.570 municipios brasileiros estao aderidos ao sistema NFS-e. O worker precisa descobrir quais municipios tem convenio ativo antes de tentar coletar aliquotas.
+Nem todos os 5.570 municipios brasileiros estao aderidos ao sistema NFS-e. O worker precisa descobrir quais municipios tem dados disponiveis antes de tentar coletar aliquotas.
 
-### Fluxo de descoberta
+**Importante:** Um municipio sem convenio formal pode ainda ter dados disponiveis na API. Por isso, o worker NAO descarta automaticamente municipios sem convenio — ele verifica tambem via endpoint CNC.
 
-1. Carregar lista completa de municipios da colecao `municipios` (seed IBGE)
+### Fluxo de descoberta (2 etapas)
+
+1. Carregar lista de municipios da colecao `municipios` (MVP: somente capitais)
 2. Para cada municipio, chamar `GET /parametrizacao/{codigoIbge}/convenio`
-3. Se a resposta for bem-sucedida (HTTP 200): marcar municipio como `ativo = true`
-4. Se a resposta for HTTP 404 ou vazia: marcar municipio como `ativo = false`
-5. Apenas municipios ativos entram na fila de coleta de aliquotas
+3. Se a resposta for bem-sucedida (HTTP 200): marcar municipio como `convenio = true`
+4. Se a resposta for HTTP 404 ou vazia: **nao descartar** — prosseguir para etapa CNC
+5. Para cada municipio (com ou sem convenio), chamar `GET /cnc/consulta/cad/{codigoIbge}`
+6. Se o CNC retornar servicos: marcar municipio como `ativo = true` e registrar servicos descobertos
+7. Se o CNC tambem falhar (municipio sem convenio E sem CNC): marcar como `ativo = false`
+8. Apenas municipios ativos (com servicos CNC) entram na fila de coleta de aliquotas
 
 ### Frequencia de redescoberta
 
@@ -126,21 +131,27 @@ Nem todos os 5.570 municipios brasileiros estao aderidos ao sistema NFS-e. O wor
 
 ```mermaid
 flowchart TD
-    A[Carregar municipios do MongoDB] --> B{Municipio ja verificado<br/>ha menos de 30 dias?}
+    A[Carregar municipios do MongoDB<br/>MVP: somente capitais] --> B{Municipio ja verificado<br/>ha menos de 30 dias?}
     B -->|Sim e ativo| C[Incluir na fila de aliquotas]
     B -->|Sim e inativo| D[Pular]
     B -->|Nao ou nunca verificado| E[Chamar endpoint convenio]
-    E -->|200 OK| F[Marcar ativo = true]
-    E -->|404 / vazio| G[Marcar ativo = false]
-    F --> C
-    G --> D
+    E -->|200 OK| F[Marcar convenio = true]
+    E -->|404 / vazio| F2[Sem convenio]
+    F --> G[Chamar endpoint CNC]
+    F2 --> G
+    G -->|CNC retornou servicos| H[Marcar ativo = true]
+    G -->|CNC vazio/404| I{Tem convenio?}
+    I -->|Sim| H2[Marcar ativo = true<br/>usar seed de servicos]
+    I -->|Nao| D2[Marcar ativo = false — Pular]
+    H --> C
+    H2 --> C
 ```
 
 ---
 
 ## Descoberta e Seed de Codigos de Servico
 
-Os codigos de servico seguem a tabela da LC 116/2003 (Lei Complementar). O sistema mantem uma colecao `servicos` com seed inicial.
+Os codigos de servico seguem a tabela da LC 116/2003 (Lei Complementar). O sistema mantem uma colecao `servicos` com seed inicial, mas a descoberta principal de servicos por municipio e feita via endpoint CNC.
 
 ### Seed da LC 116/2003
 
@@ -151,17 +162,22 @@ A tabela da LC 116/2003 define aproximadamente 600 codigos de servico tributavei
 - `descricao`: descricao do servico
 - `subitem`: subitem da lista
 
-### Estrategia de combinacao
+### Descoberta de servicos via CNC (estrategia principal)
 
-Para cada municipio ativo, o worker gera combinacoes `municipio + servico` para consulta de aliquota. O volume total e controlado pela estrategia de MVP (ver secao [Estrategia de MVP](#estrategia-de-mvp)).
+O endpoint `GET /cnc/consulta/cad/{municipio}` retorna a lista de servicos cadastrados pelo municipio. Esta e a estrategia principal para determinar quais servicos consultar para cada municipio:
 
-### Uso potencial do endpoint CNC
+- Chamado uma vez por municipio antes de gerar a fila de servicos
+- Retorna diretamente os servicos validos, eliminando a necessidade de iterar todos os ~391 codigos nacionais
+- Reduz drasticamente o volume de requests comparado com a iteracao bruta
+- Os servicos descobertos pelo CNC sao enfileirados diretamente para consulta de aliquota
 
-O endpoint `GET /cnc/consulta/cad/{municipio}` pode retornar informacoes sobre quais servicos o municipio cadastrou. Se confirmado em testes:
+### Estrategia de combinacao (revisada)
 
-- Pode ser usado para reduzir o numero de combinacoes (consultar apenas servicos que o municipio efetivamente oferece)
-- Seria chamado uma vez por municipio antes de gerar a fila
-- Esta pendente de validacao (ver Open Questions no design.md)
+Para cada municipio ativo:
+1. Chamar endpoint CNC para obter servicos cadastrados
+2. Enfileirar diretamente os servicos retornados pelo CNC
+3. Para desdobramentos municipais (complemento `xxx`) nao cobertos pelo CNC, usar iteracao com early-stop agressivo: se `001` retornar 404, parar imediatamente
+4. Retry de 3 tentativas apenas para erros (nao para 404)
 
 ---
 
@@ -291,9 +307,9 @@ SemaphoreSlim _semaphore = new SemaphoreSlim(maxConcurrency); // default: 3
 
 ### Justificativa do default
 
-- A API NFS-e nao documenta limite de conexoes simultaneas
+- A API NFS-e nao documenta limite de conexoes simultaneas nem rate limit oficial
 - 3 conexoes simultaneas evita sobrecarga na API externa
-- Combinado com o rate limit de 10 req/s, oferece throughput suficiente
+- Combinado com o rate limit de 5 req/s, oferece throughput suficiente
 - Pode ser aumentado progressivamente apos monitoramento
 
 ---
@@ -305,18 +321,19 @@ O worker impoe um limite maximo de requisicoes por segundo para evitar sobrecarg
 ### Implementacao
 
 - Token bucket ou sliding window counter
-- Default: **10 requisicoes por segundo**
+- Default: **5 requisicoes por segundo** (conservador — API nao documenta rate limit oficial)
 - Se o limite for atingido, a proxima requisicao aguarda ate a janela seguinte
+- Em caso de erro (nao 404), o worker aplica rate de 3 retries antes de desistir do item
 
 ### Interacao com concorrencia
 
 O rate limiting atua como um segundo controle alem do semaforo:
 
 ```
-Cenario: maxConcurrency = 3, rateLimit = 10/s
+Cenario: maxConcurrency = 3, rateLimit = 5/s
 
-- Se cada request leva 500ms: 3 slots x 2 req/s = 6 req/s (abaixo do rate limit)
-- Se cada request leva 100ms: 3 slots x 10 req/s = 30 req/s (rate limit ativa, reduz para 10/s)
+- Se cada request leva 500ms: 3 slots x 2 req/s = 6 req/s (rate limit ativa, reduz para 5/s)
+- Se cada request leva 1000ms: 3 slots x 1 req/s = 3 req/s (abaixo do rate limit)
 ```
 
 O rate limiter garante que mesmo com requests rapidos, o worker nao exceda o limite configurado.
@@ -568,7 +585,7 @@ Todas as configuracoes do worker sao expostas via `appsettings.json` e podem ser
   "Worker": {
     "CronSchedule": "0 2 * * *",
     "MaxConcurrency": 3,
-    "RateLimitPerSecond": 10,
+    "RateLimitPerSecond": 5,
     "RequestTimeoutSeconds": 30,
     "Retry": {
       "MaxAttempts": 3,
@@ -595,7 +612,7 @@ Todas as configuracoes do worker sao expostas via `appsettings.json` e podem ser
 |-----------|---------|-----------|
 | CronSchedule | `0 2 * * *` | Expressao CRON para agendamento (default: diario as 02:00 UTC) |
 | MaxConcurrency | 3 | Numero maximo de chamadas simultaneas a API NFS-e |
-| RateLimitPerSecond | 10 | Maximo de requisicoes por segundo |
+| RateLimitPerSecond | 5 | Maximo de requisicoes por segundo |
 | RequestTimeoutSeconds | 30 | Timeout por requisicao individual a API |
 | Retry.MaxAttempts | 3 | Maximo de tentativas por item |
 | Retry.BaseDelaySeconds | 30 | Delay base para exponential backoff |
@@ -624,70 +641,77 @@ Worker__CircuitBreaker__ErrorThresholdPercent=60
 
 ## Estimativa de Volume
 
-### Numeros de referencia
+### Numeros de referencia (revisados com CNC)
 
 | Dado | Quantidade |
 |------|------------|
 | Municipios brasileiros (IBGE) | 5.570 |
-| Codigos de servico (LC 116/2003) | ~600 |
-| Combinacoes totais (municipio x servico) | ~3.342.000 |
-| Municipios com convenio ativo (estimativa) | ~2.000 a 3.000 |
-| Combinacoes efetivas estimadas | ~1.200.000 a 1.800.000 |
+| Codigos de servico (seed LC 116/2003) | ~600 |
+| Servicos medios por municipio (via CNC) | ~50 |
+| Municipios MVP (capitais) | 27 |
+| Requests descoberta MVP | ~54 (convenio + CNC) |
+| Requests coleta MVP | ~1.350 (27 x ~50) |
+| Total MVP | ~1.400 requests |
+| Municipios com dados (estimativa) | ~2.000 a 3.000 |
+| Requests descoberta completa | ~11.140 (convenio + CNC) |
+| Requests coleta completa | ~125.000 (2.500 x ~50) |
 
-### Estimativa de tempo (coleta completa)
+### Estimativa de tempo (coleta completa com CNC)
 
 Com as configuracoes default:
 
 ```
-Rate limit: 10 req/s
-Combinacoes efetivas: ~1.500.000 (estimativa media)
-Tempo estimado: 1.500.000 / 10 = 150.000 segundos = ~41 horas
-
-Com MaxConcurrency=3 e requests de ~500ms:
-Throughput real: ~6 req/s (limitado pela latencia)
-Tempo estimado: 1.500.000 / 6 = ~69 horas
+Rate limit: 5 req/s
+MVP (27 capitais): ~1.400 / 5 = ~5 minutos
+Fase 2 (100 municipios): ~5.200 / 5 = ~17 minutos
+Fase 3 (2.500 municipios): ~125.000 / 5 = ~7 horas
 ```
 
-Isso confirma que uma coleta completa de todos os municipios e inviavel em um unico ciclo diario. A estrategia de MVP e essencial.
+A descoberta via CNC reduz drasticamente o volume comparado com a estrategia anterior de iteracao bruta (~95K para MVP vs ~1.4K com CNC).
 
 ### Estimativa de armazenamento
 
 ```
 Tamanho medio por documento aliquota: ~500 bytes
-1.500.000 documentos: ~750 MB
-Com indices: ~1 GB total estimado
+MVP (1.350 documentos): ~675 KB
+Completo (125.000 documentos): ~62.5 MB
+Com indices: ~100 MB total estimado
 ```
 
 ---
 
 ## Estrategia de MVP
 
-Dada a impossibilidade de coletar todos os municipios em um ciclo diario, o MVP adota uma abordagem progressiva.
+Dada a impossibilidade de coletar todos os municipios em um ciclo diario, o MVP adota uma abordagem progressiva. O seed inicial inclui todos os estados e municipios do IBGE, mas o crawler processa somente capitais.
 
 ### Fase 1: Capitais (27 municipios)
 
 ```
 Municipios: 27 capitais estaduais
-Combinacoes: 27 x 600 = ~16.200
-Tempo estimado: 16.200 / 10 = ~27 minutos
+Descoberta: 27 convenio + 27 CNC = 54 requests
+Servicos estimados: ~50 por capital via CNC = ~1.350
+Tempo estimado: ~1.400 / 5 = ~5 minutos
 ```
 
-Essa fase e totalmente viavel em um ciclo diario e permite validar toda a infraestrutura do worker.
+Essa fase e totalmente viavel em um ciclo diario e permite validar toda a infraestrutura do worker. Com CNC, o volume e drasticamente menor que a estimativa anterior baseada em iteracao bruta.
 
 ### Fase 2: Capitais + municipios mais populosos (100 municipios)
 
 ```
 Municipios: ~100 (capitais + maiores por populacao)
-Combinacoes: 100 x 600 = ~60.000
-Tempo estimado: 60.000 / 10 = ~100 minutos (~1h40)
+Descoberta: 100 convenio + 100 CNC = 200 requests
+Servicos estimados: ~50 por municipio via CNC = ~5.000
+Tempo estimado: ~5.200 / 5 = ~17 minutos
 ```
 
-### Fase 3: Todos os municipios com convenio ativo
+### Fase 3: Todos os municipios com dados disponiveis
 
 ```
-Municipios: ~2.000 a 3.000
-Combinacoes: ~1.200.000 a 1.800.000
+Municipios: ~2.000 a 3.000 (com convenio OU com CNC)
+Descoberta: ~5.570 convenio + ~5.570 CNC = ~11.140 requests
+Servicos estimados: ~50 por municipio x 2.500 = ~125.000
 Estrategia: processar em multiplos ciclos, priorizando municipios sem dados
+Tempo estimado por ciclo: ~125.000 / 5 = ~7 horas
 ```
 
 Para a Fase 3, o processamento incremental e essencial: cada ciclo diario processa apenas o delta (novos municipios ou servicos nao coletados).

--- a/openspec/changes/full-stack-aliquotas-municipais/specs/backend-api/spec.md
+++ b/openspec/changes/full-stack-aliquotas-municipais/specs/backend-api/spec.md
@@ -139,3 +139,30 @@ The backend SHALL include a seed mechanism to populate states and municipalities
 #### Scenario: Seed data format
 - **WHEN** the seed reads `context/municipios.json`
 - **THEN** each municipality is stored with codigoIbge as string (7 digits from Codigo field), nome, and siglaEstado (from Uf field)
+
+---
+
+### Requirement: Certificate management endpoints
+The backend SHALL expose REST endpoints for managing the PFX client certificate used by the worker to authenticate with the NFS-e API. These endpoints SHALL require authentication with admin role.
+
+#### Scenario: Certificate upload
+- **WHEN** an admin user calls `POST /api/v1/crawler/certificado` with a PFX file (multipart/form-data) and password
+- **THEN** the system stores the certificate securely and returns HTTP 201 with certificate metadata (thumbprint, validade)
+
+#### Scenario: Certificate status
+- **WHEN** an authenticated user calls `GET /api/v1/crawler/certificado`
+- **AND** a certificate has been uploaded
+- **THEN** the system returns HTTP 200 with certificate metadata (thumbprint, validade, data de upload)
+
+#### Scenario: Certificate not configured
+- **WHEN** an authenticated user calls `GET /api/v1/crawler/certificado`
+- **AND** no certificate has been uploaded
+- **THEN** the system returns HTTP 404 with `{ erro: "Certificado não configurado" }`
+
+#### Scenario: Certificate removal
+- **WHEN** an admin user calls `DELETE /api/v1/crawler/certificado`
+- **THEN** the system removes the current certificate and returns HTTP 204
+
+#### Scenario: Non-admin access
+- **WHEN** a non-admin authenticated user calls `POST` or `DELETE` on `/api/v1/crawler/certificado`
+- **THEN** the system returns HTTP 403 Forbidden

--- a/openspec/changes/full-stack-aliquotas-municipais/specs/data-crawler/spec.md
+++ b/openspec/changes/full-stack-aliquotas-municipais/specs/data-crawler/spec.md
@@ -35,7 +35,7 @@ The worker SHALL use a persistent work queue (MongoDB collection `fila_processam
 ---
 
 ### Requirement: NFS-e API integration
-The worker SHALL call the NFS-e API at `adn.nfse.gov.br` using HTTPS with client certificate (PFX). The primary endpoint is `GET /parametrizacao/{codigoMunicipio}/{codigoServico}/{competencia}/aliquota`. The worker SHALL also use `GET /parametrizacao/{codigoMunicipio}/convenio` to discover municipality adherence.
+The worker SHALL call the NFS-e API at `adn.nfse.gov.br` using HTTPS with client certificate (PFX). The primary endpoint is `GET /parametrizacao/{codigoMunicipio}/{codigoServico}/{competencia}/aliquota`. The worker SHALL also use `GET /parametrizacao/{codigoMunicipio}/convenio` to discover municipality adherence, and `GET /cnc/consulta/cad/{codigoMunicipio}` to discover registered services per municipality. The PFX certificate SHALL be managed via API endpoint (upload by admin), not mounted as a Docker volume.
 
 #### Scenario: Successful tax rate fetch
 - **WHEN** the API returns HTTP 200 with valid tax rate data
@@ -145,47 +145,62 @@ The worker SHALL support incremental processing — only fetch data that has not
 
 ---
 
-### Requirement: Service code discovery with municipal complement early-stop
-The worker SHALL maintain a seed of ~391 national tax codes (cTribNac, format `ii.ss.dd`) sourced from the gov.br/nfse portal. These derive from the 40 items and ~197 subitems of LC 116/2003, extended with national desdobramentos by the ADN. The full code format is `ii.ss.dd.xxx` where `ii.ss.dd` is the national code and `xxx` is the municipal complement (cTribMun), which varies by municipality. The worker SHALL iterate municipal complements starting at 001, and MUST stop iterating for a given national code after 9 consecutive misses (no data returned). This early-stop drastically reduces API calls. The worker SHALL use the convenio endpoint to discover active municipalities. The worker SHOULD use the CNC endpoint if it provides service discovery.
+### Requirement: Service code discovery via CNC with municipal complement early-stop
+The worker SHALL use the CNC endpoint (`GET /cnc/consulta/cad/{municipio}`) as the primary mechanism for discovering which services a municipality has registered. This replaces the previous strategy of iterating all ~391 national codes with probe and early-stop. The worker SHALL maintain a seed of ~391 national tax codes (cTribNac, format `ii.ss.dd`) sourced from the gov.br/nfse portal as fallback reference. The full code format is `ii.ss.dd.xxx` where `ii.ss.dd` is the national code and `xxx` is the municipal complement (cTribMun), which varies by municipality. When iterating municipal complements for codes not covered by CNC, the worker SHALL use aggressive early-stop: start at `000`, advance to `001`, and if `001` returns no data, stop immediately for that national code.
 
-#### Scenario: Municipal complement iteration with early-stop
-- **WHEN** the worker iterates complements for national code `01.01.01` starting at `01.01.01.001`
-- **AND** complements 001 through 009 all return 404 (no data)
-- **THEN** the worker stops iterating that national code and moves to the next (`01.01.02`)
+#### Scenario: CNC discovery replaces brute-force iteration
+- **WHEN** the worker starts processing a municipality that passed the convênio or CNC check
+- **THEN** the worker calls `GET /cnc/consulta/cad/{municipio}` to get the list of registered services
+- **AND** enqueues only the services returned by the CNC endpoint
+
+#### Scenario: Municipal complement iteration with aggressive early-stop
+- **WHEN** the worker iterates complements for a national code not covered by CNC, starting at `000`
+- **AND** complement `001` returns 404 (no data)
+- **THEN** the worker stops iterating that national code and moves to the next
 
 #### Scenario: Complement found then gap
-- **WHEN** the worker finds data for `01.01.01.001` but then 002 through 010 return 404 (9 consecutive misses)
-- **THEN** the worker stops iterating that national code since no more complements are expected
+- **WHEN** the worker finds data for `01.01.01.000` but `01.01.01.001` returns 404
+- **THEN** the worker stops iterating that national code immediately (aggressive early-stop)
 
 #### Scenario: Municipality discovery via convênio
 - **WHEN** the worker calls `GET /parametrizacao/{municipio}/convenio` and receives a successful response
-- **THEN** the municipality is marked as active and proceeds to the probe phase
+- **THEN** the municipality is marked as having convênio and proceeds to CNC discovery
 
-#### Scenario: Municipality not adherent
+#### Scenario: Municipality without convênio but with CNC data
 - **WHEN** the convênio endpoint returns 404 or empty response
-- **THEN** the municipality is marked as "sem_convenio" and skipped in subsequent cycles
+- **AND** the CNC endpoint `GET /cnc/consulta/cad/{municipio}` returns services
+- **THEN** the municipality is still processed with the services discovered via CNC
+
+#### Scenario: Municipality without convênio and without CNC data
+- **WHEN** the convênio endpoint returns 404 or empty response
+- **AND** the CNC endpoint also returns 404 or empty response
+- **THEN** the municipality is marked as "sem_dados" and skipped in subsequent cycles
 
 ---
 
-### Requirement: Municipality probe before full crawl
-Before queueing all service codes for a municipality, the worker SHALL run a probe phase: test 3-5 representative service codes (from different groups). If ALL probe calls return 404/error, the municipality SHALL be marked as "sem_dados_adn" and skipped entirely. This prevents wasting thousands of requests on municipalities that are technically conveniados but have no parametrization data in the ADN. Only municipalities that pass the probe (at least 1 successful response) SHALL have their full service code list enqueued.
+### Requirement: Municipality validation before full crawl
+Before queueing all service codes for a municipality, the worker SHALL validate the municipality using a two-step process: (1) check convênio via `GET /parametrizacao/{municipio}/convenio`, (2) discover services via CNC `GET /cnc/consulta/cad/{municipio}`. A municipality is eligible for crawling if EITHER the convênio check succeeds OR the CNC returns services. This ensures municipalities that may have data without formal convênio are not missed.
 
-#### Scenario: Probe succeeds
-- **WHEN** the worker probes municipality 3106200 with 5 representative service codes
-- **AND** at least 1 probe returns HTTP 200 with data
-- **THEN** the municipality passes the probe and its full service code list is enqueued for processing
+#### Scenario: Municipality with convênio and CNC data
+- **WHEN** the worker checks municipality 3106200
+- **AND** the convênio endpoint returns HTTP 200
+- **AND** the CNC endpoint returns a list of services
+- **THEN** the municipality passes validation and its CNC-discovered services are enqueued for processing
 
-#### Scenario: Probe fails completely
-- **WHEN** the worker probes a municipality with 5 representative service codes
-- **AND** all 5 return 404 or error
-- **THEN** the municipality is marked as "sem_dados_adn" and skipped — no further service codes are tested
+#### Scenario: Municipality without convênio but with CNC data
+- **WHEN** the worker checks a municipality
+- **AND** the convênio endpoint returns 404
+- **AND** the CNC endpoint returns a list of services
+- **THEN** the municipality passes validation and its CNC-discovered services are enqueued
 
-#### Scenario: Probe representative codes
-- **WHEN** the worker selects probe service codes
-- **THEN** it SHALL use codes from different groups (e.g., 01.01.01.001, 07.02.01.001, 14.01.01.001, 17.01.01.001, 25.01.01.001) to maximize coverage across the LC 116 table
+#### Scenario: Municipality fails both checks
+- **WHEN** the worker checks a municipality
+- **AND** the convênio endpoint returns 404 or error
+- **AND** the CNC endpoint returns 404 or empty
+- **THEN** the municipality is marked as "sem_dados" and skipped — no further service codes are tested
 
 #### Scenario: Municipality skip persists across cycles
-- **WHEN** a municipality was marked as "sem_dados_adn" in a previous cycle
+- **WHEN** a municipality was marked as "sem_dados" in a previous cycle
 - **THEN** it is skipped in subsequent cycles unless a force reprocess is triggered
 
 ---

--- a/openspec/changes/full-stack-aliquotas-municipais/specs/docker-infra/spec.md
+++ b/openspec/changes/full-stack-aliquotas-municipais/specs/docker-infra/spec.md
@@ -61,9 +61,13 @@ The project SHALL use `.env` file (gitignored) for environment-specific configur
 
 ---
 
-### Requirement: PFX certificate mounting
-The docker-compose SHALL support mounting the PFX client certificate for the NFS-e API via a volume. The certificate path SHALL be configurable via environment variable.
+### Requirement: PFX certificate management
+The PFX client certificate for the NFS-e API SHALL be managed via API endpoints (upload by admin user), NOT mounted as a Docker volume. The docker-compose SHALL NOT require a PFX file to start the stack. The worker SHALL check for certificate availability at runtime and report `sem_certificado` status if none has been uploaded.
 
-#### Scenario: Certificate available to worker
-- **WHEN** a PFX file is placed in the configured path and docker compose starts
-- **THEN** the worker can use the certificate for mTLS connections to the NFS-e API
+#### Scenario: Stack starts without certificate
+- **WHEN** docker compose starts and no PFX certificate has been uploaded
+- **THEN** all services start normally; the worker reports status `sem_certificado` and does not attempt API calls
+
+#### Scenario: Certificate uploaded at runtime
+- **WHEN** an admin uploads a PFX certificate via `POST /api/v1/crawler/certificado`
+- **THEN** the worker can use the certificate for mTLS connections without container restart


### PR DESCRIPTION
## Summary

Resolve as 5 Open Questions que estavam em aberto no `design.md` da change `full-stack-aliquotas-municipais`, propagando os impactos para todas as specs e docs afetadas.

## Respostas aplicadas

| # | Questão | Resposta |
|---|---------|----------|
| 1 | Municípios no seed inicial | Todos os estados + **somente capitais** no MVP |
| 2 | Rate limit da API NFS-e | Early-stop agressivo nos desdobramentos (1 miss → para); rate de 3 retries por erro |
| 3 | Endpoint CNC retorna serviços? | **Sim** — usar CNC como estratégia principal de descoberta (substitui probe + iteração bruta LC 116) |
| 4 | Município sem convênio | Pode ter dados — verificar via CNC antes de descartar |
| 5 | Certificado PFX | Via **endpoint REST** (admin only), não via volume Docker |

## Arquivos alterados

- **`design.md`**: Open Questions → Resolved Questions; D4 strategy com CNC; R2, R4, R5 atualizados; estimativas de volume revisadas
- **`specs/data-crawler/spec.md`**: CNC discovery substitui probe; early-stop agressivo; validação 2-step (convênio + CNC) para municípios
- **`specs/backend-api/spec.md`**: Adicionado requirement de certificate management endpoints (POST/GET/DELETE)
- **`specs/docker-infra/spec.md`**: PFX via API ao invés de volume Docker
- **`docs/worker-strategy.md`**: Descoberta via CNC; rate limit 5 req/s; estimativas de volume drasticamente reduzidas (~95K → ~1.4K para MVP)

## Impacto principal

A descoberta via CNC reduz o volume de requests do MVP de **~95K** (iteração bruta) para **~1.4K** (CNC direto), estimando ~5 min ao invés de ~5.3h para as 27 capitais.