### PR TITLE
docs: links no README, motivacao auth, perfis User/Admin, remover Sakai

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ docker compose up --build
 **Stack:**
 - **Backend:** .NET 10, ASP.NET Core, MongoDB Driver, JWT Bearer, FluentValidation, FluentResults
 - **Worker:** BackgroundService .NET com CRON, mTLS/PFX para API NFS-e
-- **Frontend:** Angular 21, PrimeNG, Tailwind CSS, Sakai layout
+- **Frontend:** Angular 21, PrimeNG, Tailwind CSS
 - **Banco:** MongoDB
 - **Infra:** Docker Compose, Nginx reverse proxy
 - **Testes:** xUnit + Moq + Testcontainers (backend), Vitest + Testing Library (frontend), Cypress (E2E)
@@ -72,8 +72,8 @@ docker compose up --build
 ├── frontend/MapaTributario-ui/
 │   └── src/app/
 │       ├── core/                # Auth, guards, interceptors
-│       ├── features/            # Auth, consulta, errors
-│       ├── layout/              # Sakai layout components
+│       ├── features/            # Auth, consulta, admin, errors
+│       ├── layout/              # Layout components (topbar, sidebar, menu, footer)
 │       └── shared/              # Componentes reutilizaveis
 ├── cypress/                     # Testes E2E
 ├── context/                     # Dados de referencia (municipios.json)
@@ -81,6 +81,23 @@ docker compose up --build
 ├── docker-compose.yml
 └── .env.example
 ```
+
+---
+
+## Documentacao
+
+| Documento | Descricao |
+|-----------|-----------|
+| [Produto](docs/product-doc.md) | Visao geral do produto, personas, motivacao para autenticacao, escopo MVP |
+| [Arquitetura Tecnica](docs/technical-doc.md) | Stack, decisoes arquiteturais (ADRs), estrutura de camadas, seguranca |
+| [Contratos da API](docs/api-contracts.md) | Endpoints, payloads, codigos de resposta, exemplos de requisicao |
+| [Estrategia de Testes](docs/test-strategy.md) | Piramide de testes, cobertura, convencoes de nomenclatura |
+| [Estrategia do Worker](docs/worker-strategy.md) | Crawler: fases de execucao, early-stop, protecao do certificado |
+| [Fundacao Frontend](docs/frontend-foundation.md) | Estrutura Angular, componentes de layout, design tokens, rotas |
+| [Design System](docs/design-system.md) | Componentes visuais, paleta de cores, tipografia |
+| [Design Tokens](docs/design-tokens.md) | Tokens CSS, variaveis de tema, personalizacao PrimeNG |
+| [Estrategia de PRs](docs/pr-strategy.md) | Fluxo de branches, convencao de commits, processo de review |
+| [API Externa NFS-e](docs/external-api-analysis.md) | Analise da API adn.nfse.gov.br, endpoints, autenticacao mTLS |
 
 ---
 
@@ -147,7 +164,7 @@ npx cypress run
 | POST | /api/v1/auth/login | Login (retorna JWT) |
 | POST | /api/v1/auth/refresh | Refresh do access token |
 
-### Consulta (requerem JWT)
+### Consulta (publicos)
 
 | Metodo | Endpoint | Descricao |
 |--------|----------|-----------|
@@ -156,13 +173,16 @@ npx cypress run
 | GET | /api/v1/municipios/:ibge/aliquotas | Aliquotas paginadas com filtros |
 | GET | /api/v1/municipios/:ibge/aliquotas/:servico | Detalhe de aliquota |
 
-### Crawler (requerem JWT)
+### Crawler (requerem JWT + role Admin)
 
 | Metodo | Endpoint | Descricao |
 |--------|----------|-----------|
-| POST | /api/v1/crawler/executar | Trigger manual do crawler |
+| POST | /api/v1/crawler/executar | Trigger manual do crawler (com filtro por UF) |
 | GET | /api/v1/crawler/status | Status da ultima execucao |
 | GET | /api/v1/crawler/execucoes | Historico de execucoes |
+| POST | /api/v1/crawler/certificado | Upload de certificado PFX |
+| GET | /api/v1/crawler/certificado | Status do certificado |
+| DELETE | /api/v1/crawler/certificado | Remover certificado |
 
 ### Infra
 
@@ -178,21 +198,18 @@ npx cypress run
 
 - [x] **Infra Docker** — Docker Compose, Dockerfiles, Nginx, .env
 - [x] **Backend Auth** — JWT auth (register/login/refresh), DDD, FluentResults, FluentValidation, 97% coverage
-- [x] **Frontend Foundation** — Layout Sakai, design tokens, componentes base, rotas, Vitest + Cypress base
+- [x] **Frontend Foundation** — Layout PrimeNG, design tokens, componentes base, rotas, Vitest + Cypress base
 
-### Round 2 — Em andamento
+### Round 2 — Concluido
 
-- [ ] **Backend Consulta** — Seed IBGE + endpoints de consulta com filtros e paginacao
-- [ ] **Worker Crawler** — Crawler com protecao do certificado, 3 fases, early-stop
-- [ ] **Frontend Auth** — AuthService, guards, interceptor JWT, paginas login/signup reais
-- [ ] **Docs** — Atualizacao parcial da documentacao
-
-### Pendente
-
-- [ ] **Frontend Consulta** — Mapa do Brasil, selecao estado/municipio, listagem aliquotas
-- [ ] **Integracao** — Validacao ponta a ponta
-- [ ] **E2E Cypress** — Cobertura completa de fluxos criticos
-- [ ] **Docs Final** — Documentacao completa pos-implementacao
+- [x] **Backend Consulta** — Seed IBGE + endpoints de consulta com filtros e paginacao
+- [x] **Worker Crawler** — Crawler com protecao do certificado, 3 fases, early-stop, filtro por UF
+- [x] **Frontend Auth** — AuthService, guards, interceptor JWT, paginas login/signup reais
+- [x] **Frontend Role Control** — RoleService, AdminGuard, menu condicional por role
+- [x] **Frontend Consulta** — Mapa do Brasil, selecao estado/municipio, listagem aliquotas com filtros
+- [x] **Frontend Crawler Admin** — Status, execucao manual, certificado, historico de execucoes
+- [x] **E2E Cypress** — Testes de auth, layout, navegacao, consulta e crawler admin
+- [x] **Docs** — Contratos, especificacoes, estrategias documentadas
 
 ---
 

--- a/docs/frontend-foundation.md
+++ b/docs/frontend-foundation.md
@@ -1,8 +1,8 @@
 # Fundacao do Frontend - Mapa Tributario
 
-## Analise do Template Sakai
+## Analise de Componentes de Layout
 
-O template Sakai do PrimeNG serve como base para o frontend. Cada componente foi avaliado individualmente para decidir entre reutilizar, adaptar ou descartar.
+O layout do frontend foi construido usando componentes PrimeNG como base. Cada componente foi avaliado individualmente para decidir entre construir, adaptar ou descartar.
 
 ### Decisao por Componente
 
@@ -30,12 +30,11 @@ O template Sakai do PrimeNG serve como base para o frontend. Cada componente foi
 
 A fundacao do frontend deve seguir esta sequencia. Nenhum passo pode ser pulado ou invertido.
 
-### Passo 1 - Analisar o template de referencia
+### Passo 1 - Definir estrutura de componentes
 
-- Clonar o template Sakai
-- Identificar componentes, servicos e estrutura de pastas
+- Identificar componentes necessarios para o layout (topbar, sidebar, menu, footer)
 - Mapear dependencias entre componentes
-- Documentar o que sera usado, adaptado e descartado (tabela acima)
+- Documentar o que sera construido, adaptado de componentes PrimeNG ou descartado (tabela acima)
 
 ### Passo 2 - Configurar o projeto Angular
 
@@ -78,11 +77,11 @@ Tokens principais:
 
 ### Passo 4 - Construir layout base
 
-- Adaptar `AppLayout` do Sakai
-- Adaptar `AppTopbar` (logo, toggle, dark mode, usuario)
-- Adaptar `AppSidebar` e `AppMenu` com items do Mapa Tributario
-- Reutilizar `AppMenuitem` e `AppFooter`
-- Adaptar `LayoutService` (remover preset config)
+- Construir `AppLayout` com PrimeNG components
+- Construir `AppTopbar` (logo, toggle, dark mode, usuario)
+- Construir `AppSidebar` e `AppMenu` com items do Mapa Tributario
+- Construir `AppMenuitem` recursivo e `AppFooter`
+- Construir `LayoutService` com signals de estado do layout
 - Testar layout com conteudo placeholder
 
 ### Passo 5 - Definir design system (componentes PrimeNG)
@@ -190,14 +189,14 @@ const VALIDATION_MESSAGES: Record<string, (params?: any) => string> = {
 
 ### Passo 10 - Implementar pagina de Acesso Negado (403)
 
-- Layout visual adaptado do template Sakai
+- Layout visual com PrimeNG components
 - Mensagem clara de acesso negado
 - Botao para voltar a home
 - Rota: `/access`
 
 ### Passo 11 - Implementar pagina 404
 
-- Layout visual adaptado do template Sakai
+- Layout visual com PrimeNG components
 - Mensagem de pagina nao encontrada
 - Botao para voltar a home
 - Wildcard route no router

--- a/docs/product-doc.md
+++ b/docs/product-doc.md
@@ -36,7 +36,30 @@ O Brasil possui mais de 5.500 municipios, cada um com autonomia para definir ali
 - **Materializacao local** garante leitura rapida e independencia da disponibilidade da API externa
 - **Interface visual** com mapa interativo do Brasil permite navegacao intuitiva
 - **Filtros avancados** por codigo de servico, descricao, faixa de aliquota e competencia
-- **Acesso autenticado** via web, sem necessidade de certificado digital pelo usuario final
+- **Consulta publica** via web, sem necessidade de cadastro ou certificado digital para consultar dados
+- **Cadastro opcional** permite coletar metricas de uso, identificar usuarios reais e proteger a aplicacao contra chamadas automatizadas por bots
+
+---
+
+## 3. Motivacao para Autenticacao
+
+Embora o Mapa Tributario seja uma aplicacao **gratuita** e com **endpoints de consulta publicos** (nao exigem login para consultar dados), a aplicacao mantém o fluxo de cadastro e login por razoes estrategicas:
+
+| Motivacao | Descricao |
+|-----------|-----------|
+| **Metricas de uso reais** | Identificar usuarios reais permite medir adocao, frequencia de uso, municipios mais consultados e padroes de navegacao. Dados anonimos de bots poluiriam essas metricas. |
+| **Protecao contra bots** | A barreira de autenticacao desestimula scraping automatizado e chamadas massivas por robos. Mesmo que os endpoints de consulta sejam publicos, o frontend direciona o usuario pelo fluxo de login, criando uma camada de protecao humana. |
+| **Base de usuarios identificados** | Ter uma base de usuarios cadastrados viabiliza evolucoes futuras como: alertas de mudanca de aliquota, favoritos, historico de consultas e comunicacao direta. |
+| **Separacao de perfis** | Distinguir entre usuarios comuns (consulta) e administradores (operacao do crawler) garante que operacoes criticas fiquem restritas. |
+
+### Dois perfis de usuario
+
+| Perfil | Permissoes | Como e definido |
+|--------|-----------|----------------|
+| **Usuario (User)** | Consultar estados, municipios, aliquotas; navegar pelo mapa; usar filtros; acessar toda a parte de consulta | Qualquer usuario cadastrado recebe este perfil por padrao |
+| **Administrador (Admin)** | Tudo do perfil User + executar crawler manualmente, gerenciar certificado PFX, consultar status e historico de execucoes | Email do usuario deve estar na configuracao `Admin:Emails` do backend |
+
+> **Nota:** Os endpoints de consulta da API (`/api/v1/estados`, `/api/v1/municipios`, `/api/v1/aliquotas`) sao **tecnicamente publicos** (nao exigem JWT). Contudo, o frontend direciona o usuario pelo fluxo de login antes de acessar as paginas de consulta, garantindo identificacao e coleta de metricas.
 
 ---
 
@@ -77,6 +100,18 @@ O Brasil possui mais de 5.500 municipios, cada um com autonomia para definir ali
 | **Cenario tipico** | A empresa esta abrindo filial e precisa comparar aliquotas de ISS do servico principal em 5 capitais diferentes |
 | **Expectativa** | Visao visual por mapa, navegacao por estado, filtragem rapida |
 | **Nivel tecnico** | Baixo; precisa de experiencia visual acessivel, sem jargao tecnico |
+
+### 3.4 Administrador do Sistema - Diego
+
+| Atributo | Descricao |
+|----------|-----------|
+| **Perfil** | Profissional de TI responsavel pela operacao e manutencao da aplicacao, 25-40 anos |
+| **Objetivo** | Garantir que o crawler colete dados atualizados, gerenciar o certificado PFX e monitorar execucoes |
+| **Frequencia de uso** | Semanal para monitoramento; sob demanda para execucoes manuais e troca de certificado |
+| **Dor principal** | Precisa de visibilidade sobre o status da coleta e controle sobre o ciclo de execucao |
+| **Cenario tipico** | Certificado PFX esta proximo do vencimento; precisa fazer upload do novo certificado e disparar uma execucao manual para validar que a coleta funciona |
+| **Expectativa** | Interface administrativa clara com status do crawler, historico de execucoes e gestao de certificado |
+| **Nivel tecnico** | Alto; entende de infraestrutura, APIs e certificados digitais |
 
 ---
 
@@ -135,10 +170,15 @@ flowchart TD
 
 ```mermaid
 flowchart LR
-    A[Login] --> B[Layout Autenticado]
+    A[Login] --> B[Layout Principal]
     B --> C[Menu Lateral]
     C --> D[Consulta de Aliquotas]
     D --> E[Mapa do Brasil]
+
+    C --> |Admin apenas| K[Gerenciamento do Crawler]
+    K --> K1[Executar Crawler]
+    K --> K2[Status / Historico]
+    K --> K3[Certificado PFX]
 
     B --> F[Topbar]
     F --> G[Toggle Dark Mode]
@@ -151,8 +191,14 @@ flowchart LR
 ```
 
 **Estrutura do menu lateral:**
-- Consulta de Aliquotas (item principal, leva ao mapa)
-- (Expansivel no futuro: Historico, Favoritos, Configuracoes)
+
+| Item | Visibilidade | Descricao |
+|------|-------------|-----------|
+| Consulta de Aliquotas | Todos os usuarios | Item principal, leva ao mapa interativo |
+| Gerenciamento do Crawler | Apenas Admin | Executar, status, historico de execucoes |
+| Certificado PFX | Apenas Admin | Upload, verificacao e remocao do certificado |
+
+**Nota:** Usuarios com perfil User veem apenas o menu de consulta. Administradores veem tambem o menu do crawler. Se um usuario User tentar acessar rotas de admin diretamente pela URL, e redirecionado para a pagina de acesso negado (403).
 
 ### 4.4 Consulta por Mapa
 
@@ -235,13 +281,15 @@ flowchart TD
 | **Autenticacao** | Cadastro de usuario (nome, email, senha) | Must-have |
 | **Autenticacao** | Login com JWT (access + refresh token) | Must-have |
 | **Autenticacao** | Logout | Must-have |
-| **Autenticacao** | Guard de rotas (redireciona para login) | Must-have |
+| **Autenticacao** | Guard de rotas (redireciona para login no frontend) | Must-have |
+| **Autenticacao** | Perfis User e Admin (baseado em `Admin:Emails` config) | Must-have |
 | **Autenticacao** | Pagina de acesso negado (403) | Must-have |
-| **Frontend Base** | Layout administrativo (topbar, sidebar, footer) | Must-have |
+| **Frontend Base** | Layout com topbar, sidebar e footer | Must-have |
 | **Frontend Base** | Design system e design tokens | Must-have |
 | **Frontend Base** | Componentes reutilizaveis (loading, empty, error, retry) | Must-have |
 | **Frontend Base** | Dark mode | Should-have |
 | **Frontend Base** | Pagina 404 | Must-have |
+| **Frontend Base** | Menu condicional por perfil (User vs Admin) | Must-have |
 | **Consulta** | Mapa SVG interativo do Brasil | Must-have |
 | **Consulta** | Lista de municipios por estado | Must-have |
 | **Consulta** | Tabela paginada de servicos/aliquotas por municipio | Must-have |
@@ -250,7 +298,8 @@ flowchart TD
 | **Consulta** | Breadcrumb de navegacao | Should-have |
 | **Backend** | API REST versionada (/api/v1/) | Must-have |
 | **Backend** | Endpoints de autenticacao | Must-have |
-| **Backend** | Endpoints de consulta (estados, municipios, aliquotas) | Must-have |
+| **Backend** | Endpoints de consulta publicos (estados, municipios, aliquotas) | Must-have |
+| **Backend** | Endpoints de admin protegidos (crawler, certificado) | Must-have |
 | **Backend** | Swagger/OpenAPI documentado | Must-have |
 | **Backend** | Seed de estados e municipios (IBGE) | Must-have |
 | **Backend** | Seed de codigos de servico (LC 116/2003) | Must-have |
@@ -264,8 +313,9 @@ flowchart TD
 | **Worker** | Retry com exponential backoff | Must-have |
 | **Worker** | Registro de execucoes | Must-have |
 | **Worker** | Agendamento CRON | Must-have |
-| **Worker** | Trigger manual via endpoint | Should-have |
+| **Worker** | Trigger manual via endpoint (Admin) | Should-have |
 | **Worker** | Processamento incremental | Must-have |
+| **Worker** | Gerenciamento de certificado PFX via API (Admin) | Must-have |
 | **Infra** | Docker Compose (frontend, backend, MongoDB) | Must-have |
 | **Infra** | Dockerfiles multi-stage | Must-have |
 | **E2E** | Testes Cypress para fluxos criticos | Must-have |
@@ -319,13 +369,16 @@ O MVP nao cobrira todos os 5.570 municipios brasileiros. A estrategia e:
 |-----------|---------------|
 | **Autenticacao** | JWT com access token de curta duracao (15-30 min) e refresh token de longa duracao (7 dias) |
 | **Senhas** | Hash com bcrypt (work factor >= 12); nunca armazenadas em texto claro |
-| **Certificado PFX** | Montado via volume Docker; nunca versionado no repositorio; no .gitignore |
+| **Certificado PFX** | Gerenciado via API administrativa (upload, verificacao, remocao); nunca versionado no repositorio |
 | **HTTPS** | Comunicacao frontend-backend via HTTPS em producao |
-| **Protecao de endpoints** | Todos os endpoints de consulta exigem JWT valido; health check e publico |
+| **Endpoints de consulta** | Publicos — nao exigem JWT. Acessiveis por qualquer usuario (autenticado ou nao). Motivacao: dados tributarios sao informacao publica |
+| **Endpoints do crawler** | Protegidos por JWT + role Admin. Usuarios comuns recebem 403 Forbidden |
+| **Endpoints de autenticacao** | Publicos (register, login, refresh). Health check tambem e publico |
+| **Protecao contra bots** | Frontend direciona pelo fluxo de login antes da consulta, criando barreira humana. Login exigido no frontend, mas API de consulta permanece aberta para flexibilidade tecnica |
 | **Mensagens de erro** | Nao revelam detalhes internos (stack traces, nomes de colecao, etc.) |
 | **CORS** | Configurado para aceitar apenas origens conhecidas |
 | **Validacao de entrada** | Todos os inputs sao validados e sanitizados no backend |
-| **Rate limiting na API** | Protecao contra abuso nos endpoints publicos (auth) |
+| **Rate limiting na API** | Protecao contra abuso nos endpoints publicos (auth e consulta) |
 
 ### 7.3 Disponibilidade e Resiliencia
 

--- a/docs/technical-doc.md
+++ b/docs/technical-doc.md
@@ -80,7 +80,7 @@ graph TB
 | Camada | Tecnologia | Versao | Justificativa |
 |--------|-----------|--------|---------------|
 | **Frontend** | Angular | 21 | Framework maduro para SPAs complexas; suporte a standalone components, signals e zoneless change detection |
-| **UI Components** | PrimeNG | 21 | Biblioteca rica de componentes UI para Angular; template Sakai como base controlada |
+| **UI Components** | PrimeNG | 21 | Biblioteca rica de componentes UI para Angular |
 | **CSS Framework** | Tailwind CSS | 4 | Utility-first; alta produtividade; boa integracao com PrimeNG via tailwindcss-primeui |
 | **Backend** | ASP.NET Core | .NET 10 | Framework performatico para APIs REST; excelente tooling para OpenAPI |
 | **Linguagem Backend** | C# | 13 | Tipagem forte, records, pattern matching; produtividade alta para dominio empresarial |
@@ -973,7 +973,7 @@ frontend/MapaTributario-ui/src/app/
 │   └── services/
 │       └── api.service.ts              # HttpClient base com URL prefix /api/v1
 │
-├── layout/                              # Layout autenticado (adaptado do Sakai)
+├── layout/                              # Layout principal da aplicacao
 │   ├── components/
 │   │   ├── app-layout.component.ts     # Shell principal (sidebar + content area)
 │   │   ├── app-topbar.component.ts     # Topbar: toggle dark mode, nome usuario, logout
@@ -1142,15 +1142,15 @@ frontend/MapaTributario-ui/src/app/
 | **Alternativas descartadas** | Leaflet/OpenLayers (pesado), D3.js (complexidade desproporcional), Google Maps (custo, overkill) |
 | **Consequencias** | (+) Zero dependencias, controle total, performance excelente. (-) Manutencao manual dos paths SVG (estaticos e amplamente disponiveis) |
 
-### ADR-006: Template PrimeNG Sakai como referencia controlada
+### ADR-006: Layout PrimeNG como referencia controlada
 
 | Item | Descricao |
 |------|-----------|
 | **Status** | Aceita |
-| **Contexto** | Precisa de layout administrativo solido sem construir do zero |
-| **Decisao** | Reutilizar layout/sidebar/topbar do Sakai; descartar dashboard, landing, configurator, UIKit demos |
-| **Alternativas descartadas** | Construir do zero (tempo excessivo), copiar template inteiro (divida tecnica massiva) |
-| **Consequencias** | (+) Base solida, economia de tempo. (-) Necessidade de adaptar e limpar. Mitigacao: mapeamento explicito por componente |
+| **Contexto** | Precisa de layout solido sem construir do zero |
+| **Decisao** | Construir layout proprio usando componentes PrimeNG (sidebar, topbar, menu); descartar dependencias de templates externos |
+| **Alternativas descartadas** | Construir do zero sem PrimeNG (tempo excessivo), copiar template inteiro externo (divida tecnica massiva) |
+| **Consequencias** | (+) Layout proprio e limpo, sem dependencias externas. (-) Mais trabalho inicial. Mitigacao: aproveitar os componentes prontos do PrimeNG |
 
 ### ADR-007: Fila de processamento persistente no MongoDB
 


### PR DESCRIPTION
## Summary

Atualiza a documentacao do projeto com melhorias significativas em 4 arquivos:

- **README.md**: adiciona tabela de links para todos os 10 documentos da pasta `docs/`, atualiza status do Round 2 para concluido, corrige endpoints de consulta como publicos, remove referencias ao template Sakai
- **product-doc.md**: nova secao "Motivacao para Autenticacao" explicando por que o app gratuito requer login, nova persona "Administrador do Sistema - Diego", menu condicional por perfil (User vs Admin), endpoints publicos de consulta
- **technical-doc.md**: remove referencias Sakai na tabela de stack, estrutura de pastas e ADR-006 (reescrito para referenciar componentes PrimeNG)
- **frontend-foundation.md**: substitui todas as referencias ao template Sakai por componentes PrimeNG

## Motivacao

1. O README nao tinha links para a documentacao — agora e possivel navegar diretamente para cada doc
2. A documentacao nao explicava por que uma app gratuita exige login — agora tem secao dedicada
3. Nao existia o perfil Admin nas personas — agora Diego representa o administrador
4. Referencias ao "template Sakai" estavam espalhadas nos docs — substituidas por "componentes PrimeNG" (o layout foi construido com PrimeNG, nao com o Sakai)

## Arquivos alterados

| Arquivo | Tipo de mudanca |
|---------|----------------|
| README.md | Tabela de links, status Round 2, endpoints publicos, remocao Sakai |
| docs/product-doc.md | Secao auth, persona Admin, menu condicional, seguranca |
| docs/technical-doc.md | Stack, folder structure, ADR-006 |
| docs/frontend-foundation.md | Headers, intro, passos 1/4/10/11 |