### PR TITLE
feat(#31): API endpoints CRUD para configuração do crawler (Admin)

### DIFF
--- a/backend/MapaTributario/src/MapaTributario.API/Application/Crawler/ConfiguracaoCrawlerAppService.cs
+++ b/backend/MapaTributario/src/MapaTributario.API/Application/Crawler/ConfiguracaoCrawlerAppService.cs
@@ -1,0 +1,148 @@
+using FluentResults;
+using MapaTributario.API.Application.Crawler.Contracts;
+using MapaTributario.API.Application.Errors;
+using MapaTributario.API.Domain.Entities;
+using MapaTributario.API.Domain.Interfaces;
+
+namespace MapaTributario.API.Application.Crawler;
+
+public class ConfiguracaoCrawlerAppService : IConfiguracaoCrawlerAppService
+{
+    private readonly IConfiguracaoCrawlerRepository _repository;
+    private readonly ILogger<ConfiguracaoCrawlerAppService> _logger;
+
+    public ConfiguracaoCrawlerAppService(
+        IConfiguracaoCrawlerRepository repository,
+        ILogger<ConfiguracaoCrawlerAppService> logger)
+    {
+        _repository = repository;
+        _logger = logger;
+    }
+
+    public async Task<Result<ConfiguracaoCrawlerResponse>> ObterConfiguracaoAtualAsync()
+    {
+        ConfiguracaoCrawler? configuracao = await _repository.ObterAtivaAsync();
+
+        if (configuracao is null)
+        {
+            return Result.Fail<ConfiguracaoCrawlerResponse>(
+                new NotFoundError("Nenhuma configuração ativa encontrada"));
+        }
+
+        return Result.Ok(MapearParaResponse(configuracao));
+    }
+
+    public async Task<Result<ConfiguracaoCrawlerResponse>> AtualizarConfiguracaoAsync(
+        AtualizarConfiguracaoCrawlerRequest request)
+    {
+        ConfiguracaoCrawler? configuracao = await _repository.ObterAtivaAsync();
+
+        if (configuracao is null)
+        {
+            return Result.Fail<ConfiguracaoCrawlerResponse>(
+                new NotFoundError("Nenhuma configuração ativa encontrada"));
+        }
+
+        configuracao.Atualizar(
+            request.CronSchedule,
+            request.LimiteRequisicoesPorSegundo,
+            request.OrcamentoDiario,
+            request.TamanheLoteCertificado,
+            request.PausaLoteSegundos,
+            request.TamanheLoteMongo,
+            request.MaxTentativas,
+            request.LimiteParadaAntecipada,
+            request.MaxDesdobramento,
+            request.MaxDetalhamento,
+            request.MaxFalhasConsecutivasDetalhamento,
+            request.MaxFalhasConsecutivasDesdobramento,
+            request.MaxItensParalelos,
+            request.CodigosSondagem,
+            request.ValidadeDiasProcessamento,
+            request.CircuitBreakerLimiarErroPercent,
+            request.CircuitBreakerJanelaAvaliacaoSegundos,
+            request.CircuitBreakerPausaSegundos,
+            request.CircuitBreakerAmostraMinima,
+            request.Ativo);
+
+        await _repository.AtualizarAsync(configuracao);
+
+        _logger.LogInformation(
+            "Configuração do crawler atualizada (Id={Id})",
+            configuracao.Id);
+
+        return Result.Ok(MapearParaResponse(configuracao));
+    }
+
+    public async Task<Result<ConfiguracaoCrawlerResponse>> AtualizarParcialmenteAsync(
+        AtualizarParcialConfiguracaoCrawlerRequest request)
+    {
+        ConfiguracaoCrawler? configuracao = await _repository.ObterAtivaAsync();
+
+        if (configuracao is null)
+        {
+            return Result.Fail<ConfiguracaoCrawlerResponse>(
+                new NotFoundError("Nenhuma configuração ativa encontrada"));
+        }
+
+        configuracao.AtualizarParcial(
+            request.CronSchedule,
+            request.LimiteRequisicoesPorSegundo,
+            request.OrcamentoDiario,
+            request.TamanheLoteCertificado,
+            request.PausaLoteSegundos,
+            request.TamanheLoteMongo,
+            request.MaxTentativas,
+            request.LimiteParadaAntecipada,
+            request.MaxDesdobramento,
+            request.MaxDetalhamento,
+            request.MaxFalhasConsecutivasDetalhamento,
+            request.MaxFalhasConsecutivasDesdobramento,
+            request.MaxItensParalelos,
+            request.CodigosSondagem,
+            request.ValidadeDiasProcessamento,
+            request.CircuitBreakerLimiarErroPercent,
+            request.CircuitBreakerJanelaAvaliacaoSegundos,
+            request.CircuitBreakerPausaSegundos,
+            request.CircuitBreakerAmostraMinima,
+            request.Ativo);
+
+        await _repository.AtualizarAsync(configuracao);
+
+        _logger.LogInformation(
+            "Configuração do crawler atualizada parcialmente (Id={Id})",
+            configuracao.Id);
+
+        return Result.Ok(MapearParaResponse(configuracao));
+    }
+
+    private static ConfiguracaoCrawlerResponse MapearParaResponse(ConfiguracaoCrawler entidade)
+    {
+        return new ConfiguracaoCrawlerResponse
+        {
+            Id = entidade.Id,
+            CronSchedule = entidade.CronSchedule,
+            LimiteRequisicoesPorSegundo = entidade.LimiteRequisicoesPorSegundo,
+            OrcamentoDiario = entidade.OrcamentoDiario,
+            TamanheLoteCertificado = entidade.TamanheLoteCertificado,
+            PausaLoteSegundos = entidade.PausaLoteSegundos,
+            TamanheLoteMongo = entidade.TamanheLoteMongo,
+            MaxTentativas = entidade.MaxTentativas,
+            LimiteParadaAntecipada = entidade.LimiteParadaAntecipada,
+            MaxDesdobramento = entidade.MaxDesdobramento,
+            MaxDetalhamento = entidade.MaxDetalhamento,
+            MaxFalhasConsecutivasDetalhamento = entidade.MaxFalhasConsecutivasDetalhamento,
+            MaxFalhasConsecutivasDesdobramento = entidade.MaxFalhasConsecutivasDesdobramento,
+            MaxItensParalelos = entidade.MaxItensParalelos,
+            CodigosSondagem = entidade.CodigosSondagem,
+            ValidadeDiasProcessamento = entidade.ValidadeDiasProcessamento,
+            CircuitBreakerLimiarErroPercent = entidade.CircuitBreakerLimiarErroPercent,
+            CircuitBreakerJanelaAvaliacaoSegundos = entidade.CircuitBreakerJanelaAvaliacaoSegundos,
+            CircuitBreakerPausaSegundos = entidade.CircuitBreakerPausaSegundos,
+            CircuitBreakerAmostraMinima = entidade.CircuitBreakerAmostraMinima,
+            Ativo = entidade.Ativo,
+            CriadoEm = entidade.CriadoEm,
+            AtualizadoEm = entidade.AtualizadoEm
+        };
+    }
+}

--- a/backend/MapaTributario/src/MapaTributario.API/Application/Crawler/ConfiguracaoCrawlerAppService.cs
+++ b/backend/MapaTributario/src/MapaTributario.API/Application/Crawler/ConfiguracaoCrawlerAppService.cs
@@ -21,7 +21,7 @@ public class ConfiguracaoCrawlerAppService : IConfiguracaoCrawlerAppService
 
     public async Task<Result<ConfiguracaoCrawlerResponse>> ObterConfiguracaoAtualAsync()
     {
-        ConfiguracaoCrawler? configuracao = await _repository.ObterAtivaAsync();
+        ConfiguracaoCrawler? configuracao = await _repository.ObterAtualAsync();
 
         if (configuracao is null)
         {
@@ -35,7 +35,7 @@ public class ConfiguracaoCrawlerAppService : IConfiguracaoCrawlerAppService
     public async Task<Result<ConfiguracaoCrawlerResponse>> AtualizarConfiguracaoAsync(
         AtualizarConfiguracaoCrawlerRequest request)
     {
-        ConfiguracaoCrawler? configuracao = await _repository.ObterAtivaAsync();
+        ConfiguracaoCrawler? configuracao = await _repository.ObterAtualAsync();
 
         if (configuracao is null)
         {
@@ -47,9 +47,9 @@ public class ConfiguracaoCrawlerAppService : IConfiguracaoCrawlerAppService
             request.CronSchedule,
             request.LimiteRequisicoesPorSegundo,
             request.OrcamentoDiario,
-            request.TamanheLoteCertificado,
+            request.TamanhoLoteCertificado,
             request.PausaLoteSegundos,
-            request.TamanheLoteMongo,
+            request.TamanhoLoteMongo,
             request.MaxTentativas,
             request.LimiteParadaAntecipada,
             request.MaxDesdobramento,
@@ -77,7 +77,7 @@ public class ConfiguracaoCrawlerAppService : IConfiguracaoCrawlerAppService
     public async Task<Result<ConfiguracaoCrawlerResponse>> AtualizarParcialmenteAsync(
         AtualizarParcialConfiguracaoCrawlerRequest request)
     {
-        ConfiguracaoCrawler? configuracao = await _repository.ObterAtivaAsync();
+        ConfiguracaoCrawler? configuracao = await _repository.ObterAtualAsync();
 
         if (configuracao is null)
         {
@@ -89,9 +89,9 @@ public class ConfiguracaoCrawlerAppService : IConfiguracaoCrawlerAppService
             request.CronSchedule,
             request.LimiteRequisicoesPorSegundo,
             request.OrcamentoDiario,
-            request.TamanheLoteCertificado,
+            request.TamanhoLoteCertificado,
             request.PausaLoteSegundos,
-            request.TamanheLoteMongo,
+            request.TamanhoLoteMongo,
             request.MaxTentativas,
             request.LimiteParadaAntecipada,
             request.MaxDesdobramento,
@@ -124,9 +124,9 @@ public class ConfiguracaoCrawlerAppService : IConfiguracaoCrawlerAppService
             CronSchedule = entidade.CronSchedule,
             LimiteRequisicoesPorSegundo = entidade.LimiteRequisicoesPorSegundo,
             OrcamentoDiario = entidade.OrcamentoDiario,
-            TamanheLoteCertificado = entidade.TamanheLoteCertificado,
+            TamanhoLoteCertificado = entidade.TamanhoLoteCertificado,
             PausaLoteSegundos = entidade.PausaLoteSegundos,
-            TamanheLoteMongo = entidade.TamanheLoteMongo,
+            TamanhoLoteMongo = entidade.TamanhoLoteMongo,
             MaxTentativas = entidade.MaxTentativas,
             LimiteParadaAntecipada = entidade.LimiteParadaAntecipada,
             MaxDesdobramento = entidade.MaxDesdobramento,

--- a/backend/MapaTributario/src/MapaTributario.API/Application/Crawler/Contracts/AtualizarConfiguracaoCrawlerRequest.cs
+++ b/backend/MapaTributario/src/MapaTributario.API/Application/Crawler/Contracts/AtualizarConfiguracaoCrawlerRequest.cs
@@ -5,9 +5,9 @@ public class AtualizarConfiguracaoCrawlerRequest
     public string CronSchedule { get; set; } = null!;
     public int LimiteRequisicoesPorSegundo { get; set; }
     public int OrcamentoDiario { get; set; }
-    public int TamanheLoteCertificado { get; set; }
+    public int TamanhoLoteCertificado { get; set; }
     public int PausaLoteSegundos { get; set; }
-    public int TamanheLoteMongo { get; set; }
+    public int TamanhoLoteMongo { get; set; }
     public int MaxTentativas { get; set; }
     public int LimiteParadaAntecipada { get; set; }
     public int MaxDesdobramento { get; set; }

--- a/backend/MapaTributario/src/MapaTributario.API/Application/Crawler/Contracts/AtualizarConfiguracaoCrawlerRequest.cs
+++ b/backend/MapaTributario/src/MapaTributario.API/Application/Crawler/Contracts/AtualizarConfiguracaoCrawlerRequest.cs
@@ -1,0 +1,25 @@
+namespace MapaTributario.API.Application.Crawler.Contracts;
+
+public class AtualizarConfiguracaoCrawlerRequest
+{
+    public string CronSchedule { get; set; } = null!;
+    public int LimiteRequisicoesPorSegundo { get; set; }
+    public int OrcamentoDiario { get; set; }
+    public int TamanheLoteCertificado { get; set; }
+    public int PausaLoteSegundos { get; set; }
+    public int TamanheLoteMongo { get; set; }
+    public int MaxTentativas { get; set; }
+    public int LimiteParadaAntecipada { get; set; }
+    public int MaxDesdobramento { get; set; }
+    public int MaxDetalhamento { get; set; }
+    public int MaxFalhasConsecutivasDetalhamento { get; set; }
+    public int MaxFalhasConsecutivasDesdobramento { get; set; }
+    public int MaxItensParalelos { get; set; }
+    public List<string> CodigosSondagem { get; set; } = new();
+    public int ValidadeDiasProcessamento { get; set; }
+    public int CircuitBreakerLimiarErroPercent { get; set; }
+    public int CircuitBreakerJanelaAvaliacaoSegundos { get; set; }
+    public int CircuitBreakerPausaSegundos { get; set; }
+    public int CircuitBreakerAmostraMinima { get; set; }
+    public bool Ativo { get; set; }
+}

--- a/backend/MapaTributario/src/MapaTributario.API/Application/Crawler/Contracts/AtualizarParcialConfiguracaoCrawlerRequest.cs
+++ b/backend/MapaTributario/src/MapaTributario.API/Application/Crawler/Contracts/AtualizarParcialConfiguracaoCrawlerRequest.cs
@@ -5,9 +5,9 @@ public class AtualizarParcialConfiguracaoCrawlerRequest
     public string? CronSchedule { get; set; }
     public int? LimiteRequisicoesPorSegundo { get; set; }
     public int? OrcamentoDiario { get; set; }
-    public int? TamanheLoteCertificado { get; set; }
+    public int? TamanhoLoteCertificado { get; set; }
     public int? PausaLoteSegundos { get; set; }
-    public int? TamanheLoteMongo { get; set; }
+    public int? TamanhoLoteMongo { get; set; }
     public int? MaxTentativas { get; set; }
     public int? LimiteParadaAntecipada { get; set; }
     public int? MaxDesdobramento { get; set; }

--- a/backend/MapaTributario/src/MapaTributario.API/Application/Crawler/Contracts/AtualizarParcialConfiguracaoCrawlerRequest.cs
+++ b/backend/MapaTributario/src/MapaTributario.API/Application/Crawler/Contracts/AtualizarParcialConfiguracaoCrawlerRequest.cs
@@ -1,0 +1,25 @@
+namespace MapaTributario.API.Application.Crawler.Contracts;
+
+public class AtualizarParcialConfiguracaoCrawlerRequest
+{
+    public string? CronSchedule { get; set; }
+    public int? LimiteRequisicoesPorSegundo { get; set; }
+    public int? OrcamentoDiario { get; set; }
+    public int? TamanheLoteCertificado { get; set; }
+    public int? PausaLoteSegundos { get; set; }
+    public int? TamanheLoteMongo { get; set; }
+    public int? MaxTentativas { get; set; }
+    public int? LimiteParadaAntecipada { get; set; }
+    public int? MaxDesdobramento { get; set; }
+    public int? MaxDetalhamento { get; set; }
+    public int? MaxFalhasConsecutivasDetalhamento { get; set; }
+    public int? MaxFalhasConsecutivasDesdobramento { get; set; }
+    public int? MaxItensParalelos { get; set; }
+    public List<string>? CodigosSondagem { get; set; }
+    public int? ValidadeDiasProcessamento { get; set; }
+    public int? CircuitBreakerLimiarErroPercent { get; set; }
+    public int? CircuitBreakerJanelaAvaliacaoSegundos { get; set; }
+    public int? CircuitBreakerPausaSegundos { get; set; }
+    public int? CircuitBreakerAmostraMinima { get; set; }
+    public bool? Ativo { get; set; }
+}

--- a/backend/MapaTributario/src/MapaTributario.API/Application/Crawler/Contracts/ConfiguracaoCrawlerResponse.cs
+++ b/backend/MapaTributario/src/MapaTributario.API/Application/Crawler/Contracts/ConfiguracaoCrawlerResponse.cs
@@ -1,0 +1,28 @@
+namespace MapaTributario.API.Application.Crawler.Contracts;
+
+public class ConfiguracaoCrawlerResponse
+{
+    public string Id { get; set; } = null!;
+    public string CronSchedule { get; set; } = null!;
+    public int LimiteRequisicoesPorSegundo { get; set; }
+    public int OrcamentoDiario { get; set; }
+    public int TamanheLoteCertificado { get; set; }
+    public int PausaLoteSegundos { get; set; }
+    public int TamanheLoteMongo { get; set; }
+    public int MaxTentativas { get; set; }
+    public int LimiteParadaAntecipada { get; set; }
+    public int MaxDesdobramento { get; set; }
+    public int MaxDetalhamento { get; set; }
+    public int MaxFalhasConsecutivasDetalhamento { get; set; }
+    public int MaxFalhasConsecutivasDesdobramento { get; set; }
+    public int MaxItensParalelos { get; set; }
+    public List<string> CodigosSondagem { get; set; } = new();
+    public int ValidadeDiasProcessamento { get; set; }
+    public int CircuitBreakerLimiarErroPercent { get; set; }
+    public int CircuitBreakerJanelaAvaliacaoSegundos { get; set; }
+    public int CircuitBreakerPausaSegundos { get; set; }
+    public int CircuitBreakerAmostraMinima { get; set; }
+    public bool Ativo { get; set; }
+    public DateTime CriadoEm { get; set; }
+    public DateTime AtualizadoEm { get; set; }
+}

--- a/backend/MapaTributario/src/MapaTributario.API/Application/Crawler/Contracts/ConfiguracaoCrawlerResponse.cs
+++ b/backend/MapaTributario/src/MapaTributario.API/Application/Crawler/Contracts/ConfiguracaoCrawlerResponse.cs
@@ -6,9 +6,9 @@ public class ConfiguracaoCrawlerResponse
     public string CronSchedule { get; set; } = null!;
     public int LimiteRequisicoesPorSegundo { get; set; }
     public int OrcamentoDiario { get; set; }
-    public int TamanheLoteCertificado { get; set; }
+    public int TamanhoLoteCertificado { get; set; }
     public int PausaLoteSegundos { get; set; }
-    public int TamanheLoteMongo { get; set; }
+    public int TamanhoLoteMongo { get; set; }
     public int MaxTentativas { get; set; }
     public int LimiteParadaAntecipada { get; set; }
     public int MaxDesdobramento { get; set; }

--- a/backend/MapaTributario/src/MapaTributario.API/Application/Crawler/IConfiguracaoCrawlerAppService.cs
+++ b/backend/MapaTributario/src/MapaTributario.API/Application/Crawler/IConfiguracaoCrawlerAppService.cs
@@ -1,0 +1,11 @@
+using FluentResults;
+using MapaTributario.API.Application.Crawler.Contracts;
+
+namespace MapaTributario.API.Application.Crawler;
+
+public interface IConfiguracaoCrawlerAppService
+{
+    Task<Result<ConfiguracaoCrawlerResponse>> ObterConfiguracaoAtualAsync();
+    Task<Result<ConfiguracaoCrawlerResponse>> AtualizarConfiguracaoAsync(AtualizarConfiguracaoCrawlerRequest request);
+    Task<Result<ConfiguracaoCrawlerResponse>> AtualizarParcialmenteAsync(AtualizarParcialConfiguracaoCrawlerRequest request);
+}

--- a/backend/MapaTributario/src/MapaTributario.API/Application/Crawler/Validators/AtualizarConfiguracaoCrawlerRequestValidator.cs
+++ b/backend/MapaTributario/src/MapaTributario.API/Application/Crawler/Validators/AtualizarConfiguracaoCrawlerRequestValidator.cs
@@ -5,86 +5,33 @@ namespace MapaTributario.API.Application.Crawler.Validators;
 
 public class AtualizarConfiguracaoCrawlerRequestValidator : AbstractValidator<AtualizarConfiguracaoCrawlerRequest>
 {
-    private const string PadraoCronValido = @"^(\S+\s+){4}\S+$";
-    private const string PadraoCodigoSondagem = @"^\d{2}\.\d{2}\.\d{2}$";
-
     public AtualizarConfiguracaoCrawlerRequestValidator()
     {
-        RuleFor(x => x.CronSchedule)
-            .NotEmpty().WithMessage("'{PropertyName}' não pode ser vazio")
-            .Matches(PadraoCronValido).WithMessage("'{PropertyName}' deve ser uma expressão cron válida com 5 partes");
-
-        RuleFor(x => x.LimiteRequisicoesPorSegundo)
-            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
-            .LessThanOrEqualTo(100).WithMessage("'{PropertyName}' deve ser no máximo 100");
-
-        RuleFor(x => x.OrcamentoDiario)
-            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
-            .LessThanOrEqualTo(500000).WithMessage("'{PropertyName}' deve ser no máximo 500000");
-
-        RuleFor(x => x.TamanheLoteCertificado)
-            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
-            .LessThanOrEqualTo(1000).WithMessage("'{PropertyName}' deve ser no máximo 1000");
-
-        RuleFor(x => x.PausaLoteSegundos)
-            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
-            .LessThanOrEqualTo(300).WithMessage("'{PropertyName}' deve ser no máximo 300");
-
-        RuleFor(x => x.TamanheLoteMongo)
-            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
-            .LessThanOrEqualTo(500).WithMessage("'{PropertyName}' deve ser no máximo 500");
-
-        RuleFor(x => x.MaxTentativas)
-            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
-            .LessThanOrEqualTo(10).WithMessage("'{PropertyName}' deve ser no máximo 10");
-
-        RuleFor(x => x.LimiteParadaAntecipada)
-            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
-            .LessThanOrEqualTo(50).WithMessage("'{PropertyName}' deve ser no máximo 50");
-
-        RuleFor(x => x.MaxDesdobramento)
-            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
-            .LessThanOrEqualTo(100).WithMessage("'{PropertyName}' deve ser no máximo 100");
-
-        RuleFor(x => x.MaxDetalhamento)
-            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
-            .LessThanOrEqualTo(999).WithMessage("'{PropertyName}' deve ser no máximo 999");
-
-        RuleFor(x => x.MaxFalhasConsecutivasDetalhamento)
-            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
-            .LessThanOrEqualTo(20).WithMessage("'{PropertyName}' deve ser no máximo 20");
-
-        RuleFor(x => x.MaxFalhasConsecutivasDesdobramento)
-            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
-            .LessThanOrEqualTo(20).WithMessage("'{PropertyName}' deve ser no máximo 20");
-
-        RuleFor(x => x.MaxItensParalelos)
-            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
-            .LessThanOrEqualTo(50).WithMessage("'{PropertyName}' deve ser no máximo 50");
+        RuleFor(x => x.CronSchedule).ValidarCronSchedule();
+        RuleFor(x => x.LimiteRequisicoesPorSegundo).ValidarLimiteRequisicoesPorSegundo();
+        RuleFor(x => x.OrcamentoDiario).ValidarOrcamentoDiario();
+        RuleFor(x => x.TamanhoLoteCertificado).ValidarTamanhoLoteCertificado();
+        RuleFor(x => x.PausaLoteSegundos).ValidarPausaLoteSegundos();
+        RuleFor(x => x.TamanhoLoteMongo).ValidarTamanhoLoteMongo();
+        RuleFor(x => x.MaxTentativas).ValidarMaxTentativas();
+        RuleFor(x => x.LimiteParadaAntecipada).ValidarLimiteParadaAntecipada();
+        RuleFor(x => x.MaxDesdobramento).ValidarMaxDesdobramento();
+        RuleFor(x => x.MaxDetalhamento).ValidarMaxDetalhamento();
+        RuleFor(x => x.MaxFalhasConsecutivasDetalhamento).ValidarMaxFalhasConsecutivas();
+        RuleFor(x => x.MaxFalhasConsecutivasDesdobramento).ValidarMaxFalhasConsecutivas();
+        RuleFor(x => x.MaxItensParalelos).ValidarMaxItensParalelos();
 
         RuleFor(x => x.CodigosSondagem)
             .NotEmpty().WithMessage("'{PropertyName}' não pode ser vazio");
 
         RuleForEach(x => x.CodigosSondagem)
-            .Matches(PadraoCodigoSondagem).WithMessage("Cada código de sondagem deve seguir o formato XX.XX.XX (ex: 01.01.01)");
+            .Matches(RegrasValidacaoConfiguracao.PadraoCodigoSondagem)
+            .WithMessage("Cada código de sondagem deve seguir o formato XX.XX.XX (ex: 01.01.01)");
 
-        RuleFor(x => x.ValidadeDiasProcessamento)
-            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
-            .LessThanOrEqualTo(365).WithMessage("'{PropertyName}' deve ser no máximo 365");
-
-        RuleFor(x => x.CircuitBreakerLimiarErroPercent)
-            .InclusiveBetween(1, 100).WithMessage("'{PropertyName}' deve estar entre 1 e 100");
-
-        RuleFor(x => x.CircuitBreakerJanelaAvaliacaoSegundos)
-            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
-            .LessThanOrEqualTo(3600).WithMessage("'{PropertyName}' deve ser no máximo 3600");
-
-        RuleFor(x => x.CircuitBreakerPausaSegundos)
-            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
-            .LessThanOrEqualTo(3600).WithMessage("'{PropertyName}' deve ser no máximo 3600");
-
-        RuleFor(x => x.CircuitBreakerAmostraMinima)
-            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
-            .LessThanOrEqualTo(1000).WithMessage("'{PropertyName}' deve ser no máximo 1000");
+        RuleFor(x => x.ValidadeDiasProcessamento).ValidarValidadeDiasProcessamento();
+        RuleFor(x => x.CircuitBreakerLimiarErroPercent).ValidarCircuitBreakerLimiarErroPercent();
+        RuleFor(x => x.CircuitBreakerJanelaAvaliacaoSegundos).ValidarCircuitBreakerSegundos();
+        RuleFor(x => x.CircuitBreakerPausaSegundos).ValidarCircuitBreakerSegundos();
+        RuleFor(x => x.CircuitBreakerAmostraMinima).ValidarCircuitBreakerAmostraMinima();
     }
 }

--- a/backend/MapaTributario/src/MapaTributario.API/Application/Crawler/Validators/AtualizarConfiguracaoCrawlerRequestValidator.cs
+++ b/backend/MapaTributario/src/MapaTributario.API/Application/Crawler/Validators/AtualizarConfiguracaoCrawlerRequestValidator.cs
@@ -1,0 +1,90 @@
+using FluentValidation;
+using MapaTributario.API.Application.Crawler.Contracts;
+
+namespace MapaTributario.API.Application.Crawler.Validators;
+
+public class AtualizarConfiguracaoCrawlerRequestValidator : AbstractValidator<AtualizarConfiguracaoCrawlerRequest>
+{
+    private const string PadraoCronValido = @"^(\S+\s+){4}\S+$";
+    private const string PadraoCodigoSondagem = @"^\d{2}\.\d{2}\.\d{2}$";
+
+    public AtualizarConfiguracaoCrawlerRequestValidator()
+    {
+        RuleFor(x => x.CronSchedule)
+            .NotEmpty().WithMessage("'{PropertyName}' não pode ser vazio")
+            .Matches(PadraoCronValido).WithMessage("'{PropertyName}' deve ser uma expressão cron válida com 5 partes");
+
+        RuleFor(x => x.LimiteRequisicoesPorSegundo)
+            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
+            .LessThanOrEqualTo(100).WithMessage("'{PropertyName}' deve ser no máximo 100");
+
+        RuleFor(x => x.OrcamentoDiario)
+            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
+            .LessThanOrEqualTo(500000).WithMessage("'{PropertyName}' deve ser no máximo 500000");
+
+        RuleFor(x => x.TamanheLoteCertificado)
+            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
+            .LessThanOrEqualTo(1000).WithMessage("'{PropertyName}' deve ser no máximo 1000");
+
+        RuleFor(x => x.PausaLoteSegundos)
+            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
+            .LessThanOrEqualTo(300).WithMessage("'{PropertyName}' deve ser no máximo 300");
+
+        RuleFor(x => x.TamanheLoteMongo)
+            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
+            .LessThanOrEqualTo(500).WithMessage("'{PropertyName}' deve ser no máximo 500");
+
+        RuleFor(x => x.MaxTentativas)
+            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
+            .LessThanOrEqualTo(10).WithMessage("'{PropertyName}' deve ser no máximo 10");
+
+        RuleFor(x => x.LimiteParadaAntecipada)
+            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
+            .LessThanOrEqualTo(50).WithMessage("'{PropertyName}' deve ser no máximo 50");
+
+        RuleFor(x => x.MaxDesdobramento)
+            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
+            .LessThanOrEqualTo(100).WithMessage("'{PropertyName}' deve ser no máximo 100");
+
+        RuleFor(x => x.MaxDetalhamento)
+            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
+            .LessThanOrEqualTo(999).WithMessage("'{PropertyName}' deve ser no máximo 999");
+
+        RuleFor(x => x.MaxFalhasConsecutivasDetalhamento)
+            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
+            .LessThanOrEqualTo(20).WithMessage("'{PropertyName}' deve ser no máximo 20");
+
+        RuleFor(x => x.MaxFalhasConsecutivasDesdobramento)
+            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
+            .LessThanOrEqualTo(20).WithMessage("'{PropertyName}' deve ser no máximo 20");
+
+        RuleFor(x => x.MaxItensParalelos)
+            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
+            .LessThanOrEqualTo(50).WithMessage("'{PropertyName}' deve ser no máximo 50");
+
+        RuleFor(x => x.CodigosSondagem)
+            .NotEmpty().WithMessage("'{PropertyName}' não pode ser vazio");
+
+        RuleForEach(x => x.CodigosSondagem)
+            .Matches(PadraoCodigoSondagem).WithMessage("Cada código de sondagem deve seguir o formato XX.XX.XX (ex: 01.01.01)");
+
+        RuleFor(x => x.ValidadeDiasProcessamento)
+            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
+            .LessThanOrEqualTo(365).WithMessage("'{PropertyName}' deve ser no máximo 365");
+
+        RuleFor(x => x.CircuitBreakerLimiarErroPercent)
+            .InclusiveBetween(1, 100).WithMessage("'{PropertyName}' deve estar entre 1 e 100");
+
+        RuleFor(x => x.CircuitBreakerJanelaAvaliacaoSegundos)
+            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
+            .LessThanOrEqualTo(3600).WithMessage("'{PropertyName}' deve ser no máximo 3600");
+
+        RuleFor(x => x.CircuitBreakerPausaSegundos)
+            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
+            .LessThanOrEqualTo(3600).WithMessage("'{PropertyName}' deve ser no máximo 3600");
+
+        RuleFor(x => x.CircuitBreakerAmostraMinima)
+            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
+            .LessThanOrEqualTo(1000).WithMessage("'{PropertyName}' deve ser no máximo 1000");
+    }
+}

--- a/backend/MapaTributario/src/MapaTributario.API/Application/Crawler/Validators/AtualizarParcialConfiguracaoCrawlerRequestValidator.cs
+++ b/backend/MapaTributario/src/MapaTributario.API/Application/Crawler/Validators/AtualizarParcialConfiguracaoCrawlerRequestValidator.cs
@@ -5,106 +5,115 @@ namespace MapaTributario.API.Application.Crawler.Validators;
 
 public class AtualizarParcialConfiguracaoCrawlerRequestValidator : AbstractValidator<AtualizarParcialConfiguracaoCrawlerRequest>
 {
-    private const string PadraoCronValido = @"^(\S+\s+){4}\S+$";
-    private const string PadraoCodigoSondagem = @"^\d{2}\.\d{2}\.\d{2}$";
-
     public AtualizarParcialConfiguracaoCrawlerRequestValidator()
     {
+        RuleFor(x => x)
+            .Must(PossuiAoMenosUmCampoPreenchido)
+            .WithMessage("É necessário informar ao menos um campo para atualização parcial");
+
         RuleFor(x => x.CronSchedule)
-            .NotEmpty().WithMessage("'{PropertyName}' não pode ser vazio")
-            .Matches(PadraoCronValido).WithMessage("'{PropertyName}' deve ser uma expressão cron válida com 5 partes")
+            .ValidarCronSchedule()
             .When(x => x.CronSchedule is not null);
 
-        RuleFor(x => x.LimiteRequisicoesPorSegundo)
-            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
-            .LessThanOrEqualTo(100).WithMessage("'{PropertyName}' deve ser no máximo 100")
+        RuleFor(x => x.LimiteRequisicoesPorSegundo!.Value)
+            .ValidarLimiteRequisicoesPorSegundo()
             .When(x => x.LimiteRequisicoesPorSegundo.HasValue);
 
-        RuleFor(x => x.OrcamentoDiario)
-            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
-            .LessThanOrEqualTo(500000).WithMessage("'{PropertyName}' deve ser no máximo 500000")
+        RuleFor(x => x.OrcamentoDiario!.Value)
+            .ValidarOrcamentoDiario()
             .When(x => x.OrcamentoDiario.HasValue);
 
-        RuleFor(x => x.TamanheLoteCertificado)
-            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
-            .LessThanOrEqualTo(1000).WithMessage("'{PropertyName}' deve ser no máximo 1000")
-            .When(x => x.TamanheLoteCertificado.HasValue);
+        RuleFor(x => x.TamanhoLoteCertificado!.Value)
+            .ValidarTamanhoLoteCertificado()
+            .When(x => x.TamanhoLoteCertificado.HasValue);
 
-        RuleFor(x => x.PausaLoteSegundos)
-            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
-            .LessThanOrEqualTo(300).WithMessage("'{PropertyName}' deve ser no máximo 300")
+        RuleFor(x => x.PausaLoteSegundos!.Value)
+            .ValidarPausaLoteSegundos()
             .When(x => x.PausaLoteSegundos.HasValue);
 
-        RuleFor(x => x.TamanheLoteMongo)
-            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
-            .LessThanOrEqualTo(500).WithMessage("'{PropertyName}' deve ser no máximo 500")
-            .When(x => x.TamanheLoteMongo.HasValue);
+        RuleFor(x => x.TamanhoLoteMongo!.Value)
+            .ValidarTamanhoLoteMongo()
+            .When(x => x.TamanhoLoteMongo.HasValue);
 
-        RuleFor(x => x.MaxTentativas)
-            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
-            .LessThanOrEqualTo(10).WithMessage("'{PropertyName}' deve ser no máximo 10")
+        RuleFor(x => x.MaxTentativas!.Value)
+            .ValidarMaxTentativas()
             .When(x => x.MaxTentativas.HasValue);
 
-        RuleFor(x => x.LimiteParadaAntecipada)
-            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
-            .LessThanOrEqualTo(50).WithMessage("'{PropertyName}' deve ser no máximo 50")
+        RuleFor(x => x.LimiteParadaAntecipada!.Value)
+            .ValidarLimiteParadaAntecipada()
             .When(x => x.LimiteParadaAntecipada.HasValue);
 
-        RuleFor(x => x.MaxDesdobramento)
-            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
-            .LessThanOrEqualTo(100).WithMessage("'{PropertyName}' deve ser no máximo 100")
+        RuleFor(x => x.MaxDesdobramento!.Value)
+            .ValidarMaxDesdobramento()
             .When(x => x.MaxDesdobramento.HasValue);
 
-        RuleFor(x => x.MaxDetalhamento)
-            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
-            .LessThanOrEqualTo(999).WithMessage("'{PropertyName}' deve ser no máximo 999")
+        RuleFor(x => x.MaxDetalhamento!.Value)
+            .ValidarMaxDetalhamento()
             .When(x => x.MaxDetalhamento.HasValue);
 
-        RuleFor(x => x.MaxFalhasConsecutivasDetalhamento)
-            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
-            .LessThanOrEqualTo(20).WithMessage("'{PropertyName}' deve ser no máximo 20")
+        RuleFor(x => x.MaxFalhasConsecutivasDetalhamento!.Value)
+            .ValidarMaxFalhasConsecutivas()
             .When(x => x.MaxFalhasConsecutivasDetalhamento.HasValue);
 
-        RuleFor(x => x.MaxFalhasConsecutivasDesdobramento)
-            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
-            .LessThanOrEqualTo(20).WithMessage("'{PropertyName}' deve ser no máximo 20")
+        RuleFor(x => x.MaxFalhasConsecutivasDesdobramento!.Value)
+            .ValidarMaxFalhasConsecutivas()
             .When(x => x.MaxFalhasConsecutivasDesdobramento.HasValue);
 
-        RuleFor(x => x.MaxItensParalelos)
-            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
-            .LessThanOrEqualTo(50).WithMessage("'{PropertyName}' deve ser no máximo 50")
+        RuleFor(x => x.MaxItensParalelos!.Value)
+            .ValidarMaxItensParalelos()
             .When(x => x.MaxItensParalelos.HasValue);
 
-        RuleFor(x => x.CodigosSondagem)
+        RuleFor(x => x.CodigosSondagem!)
             .NotEmpty().WithMessage("'{PropertyName}' não pode ser vazio")
             .When(x => x.CodigosSondagem is not null);
 
         RuleForEach(x => x.CodigosSondagem)
-            .Matches(PadraoCodigoSondagem).WithMessage("Cada código de sondagem deve seguir o formato XX.XX.XX (ex: 01.01.01)")
+            .Matches(RegrasValidacaoConfiguracao.PadraoCodigoSondagem)
+            .WithMessage("Cada código de sondagem deve seguir o formato XX.XX.XX (ex: 01.01.01)")
             .When(x => x.CodigosSondagem is not null);
 
-        RuleFor(x => x.ValidadeDiasProcessamento)
-            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
-            .LessThanOrEqualTo(365).WithMessage("'{PropertyName}' deve ser no máximo 365")
+        RuleFor(x => x.ValidadeDiasProcessamento!.Value)
+            .ValidarValidadeDiasProcessamento()
             .When(x => x.ValidadeDiasProcessamento.HasValue);
 
-        RuleFor(x => x.CircuitBreakerLimiarErroPercent)
-            .InclusiveBetween(1, 100).WithMessage("'{PropertyName}' deve estar entre 1 e 100")
+        RuleFor(x => x.CircuitBreakerLimiarErroPercent!.Value)
+            .ValidarCircuitBreakerLimiarErroPercent()
             .When(x => x.CircuitBreakerLimiarErroPercent.HasValue);
 
-        RuleFor(x => x.CircuitBreakerJanelaAvaliacaoSegundos)
-            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
-            .LessThanOrEqualTo(3600).WithMessage("'{PropertyName}' deve ser no máximo 3600")
+        RuleFor(x => x.CircuitBreakerJanelaAvaliacaoSegundos!.Value)
+            .ValidarCircuitBreakerSegundos()
             .When(x => x.CircuitBreakerJanelaAvaliacaoSegundos.HasValue);
 
-        RuleFor(x => x.CircuitBreakerPausaSegundos)
-            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
-            .LessThanOrEqualTo(3600).WithMessage("'{PropertyName}' deve ser no máximo 3600")
+        RuleFor(x => x.CircuitBreakerPausaSegundos!.Value)
+            .ValidarCircuitBreakerSegundos()
             .When(x => x.CircuitBreakerPausaSegundos.HasValue);
 
-        RuleFor(x => x.CircuitBreakerAmostraMinima)
-            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
-            .LessThanOrEqualTo(1000).WithMessage("'{PropertyName}' deve ser no máximo 1000")
+        RuleFor(x => x.CircuitBreakerAmostraMinima!.Value)
+            .ValidarCircuitBreakerAmostraMinima()
             .When(x => x.CircuitBreakerAmostraMinima.HasValue);
+    }
+
+    private static bool PossuiAoMenosUmCampoPreenchido(AtualizarParcialConfiguracaoCrawlerRequest request)
+    {
+        return request.CronSchedule is not null
+            || request.LimiteRequisicoesPorSegundo.HasValue
+            || request.OrcamentoDiario.HasValue
+            || request.TamanhoLoteCertificado.HasValue
+            || request.PausaLoteSegundos.HasValue
+            || request.TamanhoLoteMongo.HasValue
+            || request.MaxTentativas.HasValue
+            || request.LimiteParadaAntecipada.HasValue
+            || request.MaxDesdobramento.HasValue
+            || request.MaxDetalhamento.HasValue
+            || request.MaxFalhasConsecutivasDetalhamento.HasValue
+            || request.MaxFalhasConsecutivasDesdobramento.HasValue
+            || request.MaxItensParalelos.HasValue
+            || request.CodigosSondagem is not null
+            || request.ValidadeDiasProcessamento.HasValue
+            || request.CircuitBreakerLimiarErroPercent.HasValue
+            || request.CircuitBreakerJanelaAvaliacaoSegundos.HasValue
+            || request.CircuitBreakerPausaSegundos.HasValue
+            || request.CircuitBreakerAmostraMinima.HasValue
+            || request.Ativo.HasValue;
     }
 }

--- a/backend/MapaTributario/src/MapaTributario.API/Application/Crawler/Validators/AtualizarParcialConfiguracaoCrawlerRequestValidator.cs
+++ b/backend/MapaTributario/src/MapaTributario.API/Application/Crawler/Validators/AtualizarParcialConfiguracaoCrawlerRequestValidator.cs
@@ -1,0 +1,110 @@
+using FluentValidation;
+using MapaTributario.API.Application.Crawler.Contracts;
+
+namespace MapaTributario.API.Application.Crawler.Validators;
+
+public class AtualizarParcialConfiguracaoCrawlerRequestValidator : AbstractValidator<AtualizarParcialConfiguracaoCrawlerRequest>
+{
+    private const string PadraoCronValido = @"^(\S+\s+){4}\S+$";
+    private const string PadraoCodigoSondagem = @"^\d{2}\.\d{2}\.\d{2}$";
+
+    public AtualizarParcialConfiguracaoCrawlerRequestValidator()
+    {
+        RuleFor(x => x.CronSchedule)
+            .NotEmpty().WithMessage("'{PropertyName}' não pode ser vazio")
+            .Matches(PadraoCronValido).WithMessage("'{PropertyName}' deve ser uma expressão cron válida com 5 partes")
+            .When(x => x.CronSchedule is not null);
+
+        RuleFor(x => x.LimiteRequisicoesPorSegundo)
+            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
+            .LessThanOrEqualTo(100).WithMessage("'{PropertyName}' deve ser no máximo 100")
+            .When(x => x.LimiteRequisicoesPorSegundo.HasValue);
+
+        RuleFor(x => x.OrcamentoDiario)
+            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
+            .LessThanOrEqualTo(500000).WithMessage("'{PropertyName}' deve ser no máximo 500000")
+            .When(x => x.OrcamentoDiario.HasValue);
+
+        RuleFor(x => x.TamanheLoteCertificado)
+            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
+            .LessThanOrEqualTo(1000).WithMessage("'{PropertyName}' deve ser no máximo 1000")
+            .When(x => x.TamanheLoteCertificado.HasValue);
+
+        RuleFor(x => x.PausaLoteSegundos)
+            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
+            .LessThanOrEqualTo(300).WithMessage("'{PropertyName}' deve ser no máximo 300")
+            .When(x => x.PausaLoteSegundos.HasValue);
+
+        RuleFor(x => x.TamanheLoteMongo)
+            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
+            .LessThanOrEqualTo(500).WithMessage("'{PropertyName}' deve ser no máximo 500")
+            .When(x => x.TamanheLoteMongo.HasValue);
+
+        RuleFor(x => x.MaxTentativas)
+            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
+            .LessThanOrEqualTo(10).WithMessage("'{PropertyName}' deve ser no máximo 10")
+            .When(x => x.MaxTentativas.HasValue);
+
+        RuleFor(x => x.LimiteParadaAntecipada)
+            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
+            .LessThanOrEqualTo(50).WithMessage("'{PropertyName}' deve ser no máximo 50")
+            .When(x => x.LimiteParadaAntecipada.HasValue);
+
+        RuleFor(x => x.MaxDesdobramento)
+            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
+            .LessThanOrEqualTo(100).WithMessage("'{PropertyName}' deve ser no máximo 100")
+            .When(x => x.MaxDesdobramento.HasValue);
+
+        RuleFor(x => x.MaxDetalhamento)
+            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
+            .LessThanOrEqualTo(999).WithMessage("'{PropertyName}' deve ser no máximo 999")
+            .When(x => x.MaxDetalhamento.HasValue);
+
+        RuleFor(x => x.MaxFalhasConsecutivasDetalhamento)
+            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
+            .LessThanOrEqualTo(20).WithMessage("'{PropertyName}' deve ser no máximo 20")
+            .When(x => x.MaxFalhasConsecutivasDetalhamento.HasValue);
+
+        RuleFor(x => x.MaxFalhasConsecutivasDesdobramento)
+            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
+            .LessThanOrEqualTo(20).WithMessage("'{PropertyName}' deve ser no máximo 20")
+            .When(x => x.MaxFalhasConsecutivasDesdobramento.HasValue);
+
+        RuleFor(x => x.MaxItensParalelos)
+            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
+            .LessThanOrEqualTo(50).WithMessage("'{PropertyName}' deve ser no máximo 50")
+            .When(x => x.MaxItensParalelos.HasValue);
+
+        RuleFor(x => x.CodigosSondagem)
+            .NotEmpty().WithMessage("'{PropertyName}' não pode ser vazio")
+            .When(x => x.CodigosSondagem is not null);
+
+        RuleForEach(x => x.CodigosSondagem)
+            .Matches(PadraoCodigoSondagem).WithMessage("Cada código de sondagem deve seguir o formato XX.XX.XX (ex: 01.01.01)")
+            .When(x => x.CodigosSondagem is not null);
+
+        RuleFor(x => x.ValidadeDiasProcessamento)
+            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
+            .LessThanOrEqualTo(365).WithMessage("'{PropertyName}' deve ser no máximo 365")
+            .When(x => x.ValidadeDiasProcessamento.HasValue);
+
+        RuleFor(x => x.CircuitBreakerLimiarErroPercent)
+            .InclusiveBetween(1, 100).WithMessage("'{PropertyName}' deve estar entre 1 e 100")
+            .When(x => x.CircuitBreakerLimiarErroPercent.HasValue);
+
+        RuleFor(x => x.CircuitBreakerJanelaAvaliacaoSegundos)
+            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
+            .LessThanOrEqualTo(3600).WithMessage("'{PropertyName}' deve ser no máximo 3600")
+            .When(x => x.CircuitBreakerJanelaAvaliacaoSegundos.HasValue);
+
+        RuleFor(x => x.CircuitBreakerPausaSegundos)
+            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
+            .LessThanOrEqualTo(3600).WithMessage("'{PropertyName}' deve ser no máximo 3600")
+            .When(x => x.CircuitBreakerPausaSegundos.HasValue);
+
+        RuleFor(x => x.CircuitBreakerAmostraMinima)
+            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
+            .LessThanOrEqualTo(1000).WithMessage("'{PropertyName}' deve ser no máximo 1000")
+            .When(x => x.CircuitBreakerAmostraMinima.HasValue);
+    }
+}

--- a/backend/MapaTributario/src/MapaTributario.API/Application/Crawler/Validators/RegrasValidacaoConfiguracao.cs
+++ b/backend/MapaTributario/src/MapaTributario.API/Application/Crawler/Validators/RegrasValidacaoConfiguracao.cs
@@ -1,0 +1,140 @@
+using FluentValidation;
+
+namespace MapaTributario.API.Application.Crawler.Validators;
+
+/// <summary>
+/// Regras de validação compartilhadas entre PUT e PATCH de configuração do crawler.
+/// Centraliza limites e mensagens para evitar duplicação entre os dois validators.
+/// </summary>
+public static class RegrasValidacaoConfiguracao
+{
+    public const string PadraoCronValido = @"^(\S+\s+){4}\S+$";
+    public const string PadraoCodigoSondagem = @"^\d{2}\.\d{2}\.\d{2}$";
+
+    public static IRuleBuilderOptions<T, string> ValidarCronSchedule<T>(
+        this IRuleBuilder<T, string> regra)
+    {
+        return regra
+            .NotEmpty().WithMessage("'{PropertyName}' não pode ser vazio")
+            .Matches(PadraoCronValido).WithMessage("'{PropertyName}' deve ser uma expressão cron válida com 5 partes");
+    }
+
+    public static IRuleBuilderOptions<T, int> ValidarLimiteRequisicoesPorSegundo<T>(
+        this IRuleBuilder<T, int> regra)
+    {
+        return regra
+            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
+            .LessThanOrEqualTo(100).WithMessage("'{PropertyName}' deve ser no máximo 100");
+    }
+
+    public static IRuleBuilderOptions<T, int> ValidarOrcamentoDiario<T>(
+        this IRuleBuilder<T, int> regra)
+    {
+        return regra
+            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
+            .LessThanOrEqualTo(500000).WithMessage("'{PropertyName}' deve ser no máximo 500000");
+    }
+
+    public static IRuleBuilderOptions<T, int> ValidarTamanhoLoteCertificado<T>(
+        this IRuleBuilder<T, int> regra)
+    {
+        return regra
+            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
+            .LessThanOrEqualTo(1000).WithMessage("'{PropertyName}' deve ser no máximo 1000");
+    }
+
+    public static IRuleBuilderOptions<T, int> ValidarPausaLoteSegundos<T>(
+        this IRuleBuilder<T, int> regra)
+    {
+        return regra
+            .GreaterThanOrEqualTo(0).WithMessage("'{PropertyName}' deve ser maior ou igual a 0")
+            .LessThanOrEqualTo(300).WithMessage("'{PropertyName}' deve ser no máximo 300");
+    }
+
+    public static IRuleBuilderOptions<T, int> ValidarTamanhoLoteMongo<T>(
+        this IRuleBuilder<T, int> regra)
+    {
+        return regra
+            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
+            .LessThanOrEqualTo(500).WithMessage("'{PropertyName}' deve ser no máximo 500");
+    }
+
+    public static IRuleBuilderOptions<T, int> ValidarMaxTentativas<T>(
+        this IRuleBuilder<T, int> regra)
+    {
+        return regra
+            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
+            .LessThanOrEqualTo(10).WithMessage("'{PropertyName}' deve ser no máximo 10");
+    }
+
+    public static IRuleBuilderOptions<T, int> ValidarLimiteParadaAntecipada<T>(
+        this IRuleBuilder<T, int> regra)
+    {
+        return regra
+            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
+            .LessThanOrEqualTo(100).WithMessage("'{PropertyName}' deve ser no máximo 100");
+    }
+
+    public static IRuleBuilderOptions<T, int> ValidarMaxDesdobramento<T>(
+        this IRuleBuilder<T, int> regra)
+    {
+        return regra
+            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
+            .LessThanOrEqualTo(100).WithMessage("'{PropertyName}' deve ser no máximo 100");
+    }
+
+    public static IRuleBuilderOptions<T, int> ValidarMaxDetalhamento<T>(
+        this IRuleBuilder<T, int> regra)
+    {
+        return regra
+            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
+            .LessThanOrEqualTo(999).WithMessage("'{PropertyName}' deve ser no máximo 999");
+    }
+
+    public static IRuleBuilderOptions<T, int> ValidarMaxFalhasConsecutivas<T>(
+        this IRuleBuilder<T, int> regra)
+    {
+        return regra
+            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
+            .LessThanOrEqualTo(20).WithMessage("'{PropertyName}' deve ser no máximo 20");
+    }
+
+    public static IRuleBuilderOptions<T, int> ValidarMaxItensParalelos<T>(
+        this IRuleBuilder<T, int> regra)
+    {
+        return regra
+            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
+            .LessThanOrEqualTo(50).WithMessage("'{PropertyName}' deve ser no máximo 50");
+    }
+
+    public static IRuleBuilderOptions<T, int> ValidarValidadeDiasProcessamento<T>(
+        this IRuleBuilder<T, int> regra)
+    {
+        return regra
+            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
+            .LessThanOrEqualTo(365).WithMessage("'{PropertyName}' deve ser no máximo 365");
+    }
+
+    public static IRuleBuilderOptions<T, int> ValidarCircuitBreakerLimiarErroPercent<T>(
+        this IRuleBuilder<T, int> regra)
+    {
+        return regra
+            .InclusiveBetween(1, 100).WithMessage("'{PropertyName}' deve estar entre 1 e 100");
+    }
+
+    public static IRuleBuilderOptions<T, int> ValidarCircuitBreakerSegundos<T>(
+        this IRuleBuilder<T, int> regra)
+    {
+        return regra
+            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
+            .LessThanOrEqualTo(3600).WithMessage("'{PropertyName}' deve ser no máximo 3600");
+    }
+
+    public static IRuleBuilderOptions<T, int> ValidarCircuitBreakerAmostraMinima<T>(
+        this IRuleBuilder<T, int> regra)
+    {
+        return regra
+            .GreaterThan(0).WithMessage("'{PropertyName}' deve ser maior que 0")
+            .LessThanOrEqualTo(1000).WithMessage("'{PropertyName}' deve ser no máximo 1000");
+    }
+}

--- a/backend/MapaTributario/src/MapaTributario.API/Controllers/CrawlerController.cs
+++ b/backend/MapaTributario/src/MapaTributario.API/Controllers/CrawlerController.cs
@@ -137,9 +137,10 @@ public class CrawlerController : ControllerBase
 
         if (resultado.IsFailed)
         {
-            if (resultado.Errors.OfType<NotFoundError>().Any())
+            var erroNaoEncontrado = resultado.Errors.OfType<NotFoundError>().FirstOrDefault();
+            if (erroNaoEncontrado is not null)
             {
-                return NotFound(new { erro = resultado.Errors.First().Message });
+                return NotFound(new { erro = erroNaoEncontrado.Message });
             }
 
             return BadRequest(new { erro = resultado.Errors.First().Message });
@@ -163,9 +164,10 @@ public class CrawlerController : ControllerBase
 
         if (resultado.IsFailed)
         {
-            if (resultado.Errors.OfType<NotFoundError>().Any())
+            var erroNaoEncontrado = resultado.Errors.OfType<NotFoundError>().FirstOrDefault();
+            if (erroNaoEncontrado is not null)
             {
-                return NotFound(new { erro = resultado.Errors.First().Message });
+                return NotFound(new { erro = erroNaoEncontrado.Message });
             }
 
             return BadRequest(new { erro = resultado.Errors.First().Message });
@@ -189,9 +191,10 @@ public class CrawlerController : ControllerBase
 
         if (resultado.IsFailed)
         {
-            if (resultado.Errors.OfType<NotFoundError>().Any())
+            var erroNaoEncontrado = resultado.Errors.OfType<NotFoundError>().FirstOrDefault();
+            if (erroNaoEncontrado is not null)
             {
-                return NotFound(new { erro = resultado.Errors.First().Message });
+                return NotFound(new { erro = erroNaoEncontrado.Message });
             }
 
             return BadRequest(new { erro = resultado.Errors.First().Message });

--- a/backend/MapaTributario/src/MapaTributario.API/Controllers/CrawlerController.cs
+++ b/backend/MapaTributario/src/MapaTributario.API/Controllers/CrawlerController.cs
@@ -1,5 +1,7 @@
+using FluentValidation;
 using MapaTributario.API.Application.Crawler;
 using MapaTributario.API.Application.Crawler.Contracts;
+using MapaTributario.API.Application.Errors;
 using MapaTributario.API.Domain.Entities;
 using MapaTributario.API.Domain.Interfaces;
 using Microsoft.AspNetCore.Authorization;
@@ -16,17 +18,20 @@ public class CrawlerController : ControllerBase
     private readonly IExecucaoCrawlerRepository _execucaoRepository;
     private readonly IServiceProvider _serviceProvider;
     private readonly ICertificadoStore _certificadoStore;
+    private readonly IConfiguracaoCrawlerAppService _configuracaoAppService;
 
     public CrawlerController(
         ICrawlerExecutionGuard executionGuard,
         IExecucaoCrawlerRepository execucaoRepository,
         IServiceProvider serviceProvider,
-        ICertificadoStore certificadoStore)
+        ICertificadoStore certificadoStore,
+        IConfiguracaoCrawlerAppService configuracaoAppService)
     {
         _executionGuard = executionGuard;
         _execucaoRepository = execucaoRepository;
         _serviceProvider = serviceProvider;
         _certificadoStore = certificadoStore;
+        _configuracaoAppService = configuracaoAppService;
     }
 
     [HttpPost("executar")]
@@ -123,6 +128,76 @@ public class CrawlerController : ControllerBase
         IReadOnlyList<ExecucaoCrawler> recentes = await _execucaoRepository.GetRecentAsync(20);
 
         return Ok(recentes.Select(MapToResponse).ToList());
+    }
+
+    [HttpGet("configuracao")]
+    public async Task<IActionResult> ObterConfiguracao()
+    {
+        var resultado = await _configuracaoAppService.ObterConfiguracaoAtualAsync();
+
+        if (resultado.IsFailed)
+        {
+            if (resultado.Errors.OfType<NotFoundError>().Any())
+            {
+                return NotFound(new { erro = resultado.Errors.First().Message });
+            }
+
+            return BadRequest(new { erro = resultado.Errors.First().Message });
+        }
+
+        return Ok(resultado.Value);
+    }
+
+    [HttpPut("configuracao")]
+    public async Task<IActionResult> AtualizarConfiguracao(
+        [FromBody] AtualizarConfiguracaoCrawlerRequest request,
+        [FromServices] IValidator<AtualizarConfiguracaoCrawlerRequest> validator)
+    {
+        var validacao = await validator.ValidateAsync(request);
+        if (!validacao.IsValid)
+        {
+            return BadRequest(new { erro = "Validação falhou", detalhes = validacao.Errors.Select(e => e.ErrorMessage).ToArray() });
+        }
+
+        var resultado = await _configuracaoAppService.AtualizarConfiguracaoAsync(request);
+
+        if (resultado.IsFailed)
+        {
+            if (resultado.Errors.OfType<NotFoundError>().Any())
+            {
+                return NotFound(new { erro = resultado.Errors.First().Message });
+            }
+
+            return BadRequest(new { erro = resultado.Errors.First().Message });
+        }
+
+        return Ok(resultado.Value);
+    }
+
+    [HttpPatch("configuracao")]
+    public async Task<IActionResult> AtualizarParcialConfiguracao(
+        [FromBody] AtualizarParcialConfiguracaoCrawlerRequest request,
+        [FromServices] IValidator<AtualizarParcialConfiguracaoCrawlerRequest> validator)
+    {
+        var validacao = await validator.ValidateAsync(request);
+        if (!validacao.IsValid)
+        {
+            return BadRequest(new { erro = "Validação falhou", detalhes = validacao.Errors.Select(e => e.ErrorMessage).ToArray() });
+        }
+
+        var resultado = await _configuracaoAppService.AtualizarParcialmenteAsync(request);
+
+        if (resultado.IsFailed)
+        {
+            if (resultado.Errors.OfType<NotFoundError>().Any())
+            {
+                return NotFound(new { erro = resultado.Errors.First().Message });
+            }
+
+            return BadRequest(new { erro = resultado.Errors.First().Message });
+        }
+
+        return Ok(resultado.Value);
     }
 
     private StatusCrawlerResponse MapToResponse(ExecucaoCrawler execucao)

--- a/backend/MapaTributario/src/MapaTributario.API/Domain/Entities/ConfiguracaoCrawler.cs
+++ b/backend/MapaTributario/src/MapaTributario.API/Domain/Entities/ConfiguracaoCrawler.cs
@@ -89,16 +89,93 @@ public class ConfiguracaoCrawler
         AtualizadoEm = DateTime.UtcNow;
     }
 
-    public void AtualizarParcial(
-        int? maxItensParalelos = null,
-        int? tamanhoLoteMongo = null,
-        int? tamanhoLoteCertificado = null,
-        int? maxTentativas = null)
+    public void Atualizar(
+        string cronSchedule,
+        int limiteRequisicoesPorSegundo,
+        int orcamentoDiario,
+        int tamanhoLoteCertificado,
+        int pausaLoteSegundos,
+        int tamanhoLoteMongo,
+        int maxTentativas,
+        int limiteParadaAntecipada,
+        int maxDesdobramento,
+        int maxDetalhamento,
+        int maxFalhasConsecutivasDetalhamento,
+        int maxFalhasConsecutivasDesdobramento,
+        int maxItensParalelos,
+        List<string> codigosSondagem,
+        int validadeDiasProcessamento,
+        int circuitBreakerLimiarErroPercent,
+        int circuitBreakerJanelaAvaliacaoSegundos,
+        int circuitBreakerPausaSegundos,
+        int circuitBreakerAmostraMinima,
+        bool ativo)
     {
-        if (maxItensParalelos.HasValue) MaxItensParalelos = maxItensParalelos.Value;
-        if (tamanhoLoteMongo.HasValue) TamanhoLoteMongo = tamanhoLoteMongo.Value;
+        CronSchedule = cronSchedule;
+        LimiteRequisicoesPorSegundo = limiteRequisicoesPorSegundo;
+        OrcamentoDiario = orcamentoDiario;
+        TamanhoLoteCertificado = tamanhoLoteCertificado;
+        PausaLoteSegundos = pausaLoteSegundos;
+        TamanhoLoteMongo = tamanhoLoteMongo;
+        MaxTentativas = maxTentativas;
+        LimiteParadaAntecipada = limiteParadaAntecipada;
+        MaxDesdobramento = maxDesdobramento;
+        MaxDetalhamento = maxDetalhamento;
+        MaxFalhasConsecutivasDetalhamento = maxFalhasConsecutivasDetalhamento;
+        MaxFalhasConsecutivasDesdobramento = maxFalhasConsecutivasDesdobramento;
+        MaxItensParalelos = maxItensParalelos;
+        CodigosSondagem = codigosSondagem;
+        ValidadeDiasProcessamento = validadeDiasProcessamento;
+        CircuitBreakerLimiarErroPercent = circuitBreakerLimiarErroPercent;
+        CircuitBreakerJanelaAvaliacaoSegundos = circuitBreakerJanelaAvaliacaoSegundos;
+        CircuitBreakerPausaSegundos = circuitBreakerPausaSegundos;
+        CircuitBreakerAmostraMinima = circuitBreakerAmostraMinima;
+        Ativo = ativo;
+        MarcarAtualizado();
+    }
+
+    public void AtualizarParcial(
+        string? cronSchedule = null,
+        int? limiteRequisicoesPorSegundo = null,
+        int? orcamentoDiario = null,
+        int? tamanhoLoteCertificado = null,
+        int? pausaLoteSegundos = null,
+        int? tamanhoLoteMongo = null,
+        int? maxTentativas = null,
+        int? limiteParadaAntecipada = null,
+        int? maxDesdobramento = null,
+        int? maxDetalhamento = null,
+        int? maxFalhasConsecutivasDetalhamento = null,
+        int? maxFalhasConsecutivasDesdobramento = null,
+        int? maxItensParalelos = null,
+        List<string>? codigosSondagem = null,
+        int? validadeDiasProcessamento = null,
+        int? circuitBreakerLimiarErroPercent = null,
+        int? circuitBreakerJanelaAvaliacaoSegundos = null,
+        int? circuitBreakerPausaSegundos = null,
+        int? circuitBreakerAmostraMinima = null,
+        bool? ativo = null)
+    {
+        if (cronSchedule is not null) CronSchedule = cronSchedule;
+        if (limiteRequisicoesPorSegundo.HasValue) LimiteRequisicoesPorSegundo = limiteRequisicoesPorSegundo.Value;
+        if (orcamentoDiario.HasValue) OrcamentoDiario = orcamentoDiario.Value;
         if (tamanhoLoteCertificado.HasValue) TamanhoLoteCertificado = tamanhoLoteCertificado.Value;
+        if (pausaLoteSegundos.HasValue) PausaLoteSegundos = pausaLoteSegundos.Value;
+        if (tamanhoLoteMongo.HasValue) TamanhoLoteMongo = tamanhoLoteMongo.Value;
         if (maxTentativas.HasValue) MaxTentativas = maxTentativas.Value;
-        AtualizadoEm = DateTime.UtcNow;
+        if (limiteParadaAntecipada.HasValue) LimiteParadaAntecipada = limiteParadaAntecipada.Value;
+        if (maxDesdobramento.HasValue) MaxDesdobramento = maxDesdobramento.Value;
+        if (maxDetalhamento.HasValue) MaxDetalhamento = maxDetalhamento.Value;
+        if (maxFalhasConsecutivasDetalhamento.HasValue) MaxFalhasConsecutivasDetalhamento = maxFalhasConsecutivasDetalhamento.Value;
+        if (maxFalhasConsecutivasDesdobramento.HasValue) MaxFalhasConsecutivasDesdobramento = maxFalhasConsecutivasDesdobramento.Value;
+        if (maxItensParalelos.HasValue) MaxItensParalelos = maxItensParalelos.Value;
+        if (codigosSondagem is not null) CodigosSondagem = codigosSondagem;
+        if (validadeDiasProcessamento.HasValue) ValidadeDiasProcessamento = validadeDiasProcessamento.Value;
+        if (circuitBreakerLimiarErroPercent.HasValue) CircuitBreakerLimiarErroPercent = circuitBreakerLimiarErroPercent.Value;
+        if (circuitBreakerJanelaAvaliacaoSegundos.HasValue) CircuitBreakerJanelaAvaliacaoSegundos = circuitBreakerJanelaAvaliacaoSegundos.Value;
+        if (circuitBreakerPausaSegundos.HasValue) CircuitBreakerPausaSegundos = circuitBreakerPausaSegundos.Value;
+        if (circuitBreakerAmostraMinima.HasValue) CircuitBreakerAmostraMinima = circuitBreakerAmostraMinima.Value;
+        if (ativo.HasValue) Ativo = ativo.Value;
+        MarcarAtualizado();
     }
 }

--- a/backend/MapaTributario/src/MapaTributario.API/Extensions/ApplicationServiceExtensions.cs
+++ b/backend/MapaTributario/src/MapaTributario.API/Extensions/ApplicationServiceExtensions.cs
@@ -27,6 +27,9 @@ public static class ApplicationServiceExtensions
         services.AddScoped<ICrawlerService, CrawlerService>();
         services.AddSingleton<ICrawlerExecutionGuard, CrawlerExecutionGuard>();
 
+        // Configuração Crawler (CRUD)
+        services.AddScoped<IConfiguracaoCrawlerAppService, ConfiguracaoCrawlerAppService>();
+
         // Resilience components (singletons for shared state)
         RegisterResilienceComponents(services, configuration);
 

--- a/backend/MapaTributario/src/MapaTributario.API/Extensions/ApplicationServiceExtensions.cs
+++ b/backend/MapaTributario/src/MapaTributario.API/Extensions/ApplicationServiceExtensions.cs
@@ -31,6 +31,12 @@ public static class ApplicationServiceExtensions
         services.AddScoped<IConfiguracaoCrawlerAppService, ConfiguracaoCrawlerAppService>();
 
         // Resilience components (singletons for shared state)
+        // NOTA: Os parâmetros de RateLimiter, CircuitBreaker e CertificateProtection são lidos
+        // apenas do appsettings.json na inicialização. Os campos correspondentes em
+        // ConfiguracaoCrawler (ex: CircuitBreakerLimiarErroPercent, LimiteRequisicoesPorSegundo)
+        // ainda NÃO são aplicados dinamicamente em runtime. Futuramente, esses singletons
+        // deverão ser substituídos por instâncias que recarreguem os valores da configuração
+        // MongoDB a cada execução do crawler.
         RegisterResilienceComponents(services, configuration);
 
         // Background service

--- a/backend/MapaTributario/tests/MapaTributario.Tests.Unit/ConfiguracaoCrawlerAppServiceTests.cs
+++ b/backend/MapaTributario/tests/MapaTributario.Tests.Unit/ConfiguracaoCrawlerAppServiceTests.cs
@@ -1,0 +1,262 @@
+using FluentResults;
+using MapaTributario.API.Application.Crawler;
+using MapaTributario.API.Application.Crawler.Contracts;
+using MapaTributario.API.Application.Errors;
+using MapaTributario.API.Domain.Entities;
+using MapaTributario.API.Domain.Interfaces;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Shouldly;
+
+namespace MapaTributario.Tests.Unit;
+
+public class ConfiguracaoCrawlerAppServiceTests
+{
+    private readonly Mock<IConfiguracaoCrawlerRepository> _repository = new();
+    private readonly Mock<ILogger<ConfiguracaoCrawlerAppService>> _logger = new();
+    private readonly ConfiguracaoCrawlerAppService _sut;
+
+    public ConfiguracaoCrawlerAppServiceTests()
+    {
+        _sut = new ConfiguracaoCrawlerAppService(_repository.Object, _logger.Object);
+    }
+
+    [Fact]
+    public async Task Given_ConfiguracaoExistente_Should_RetornarConfiguracaoAtual()
+    {
+        // Arrange
+        var configuracao = ConfiguracaoCrawler.CriarPadrao();
+        configuracao.SetId("test-id");
+
+        _repository
+            .Setup(r => r.ObterAtivaAsync())
+            .ReturnsAsync(configuracao);
+
+        // Act
+        Result<ConfiguracaoCrawlerResponse> resultado = await _sut.ObterConfiguracaoAtualAsync();
+
+        // Assert
+        resultado.IsSuccess.ShouldBeTrue();
+
+        ConfiguracaoCrawlerResponse resposta = resultado.Value;
+        resposta.Id.ShouldBe("test-id");
+        resposta.CronSchedule.ShouldBe("0 2 * * *");
+        resposta.LimiteRequisicoesPorSegundo.ShouldBe(15);
+        resposta.OrcamentoDiario.ShouldBe(50000);
+        resposta.TamanheLoteCertificado.ShouldBe(200);
+        resposta.PausaLoteSegundos.ShouldBe(5);
+        resposta.TamanheLoteMongo.ShouldBe(50);
+        resposta.MaxTentativas.ShouldBe(3);
+        resposta.LimiteParadaAntecipada.ShouldBe(9);
+        resposta.MaxDesdobramento.ShouldBe(20);
+        resposta.MaxDetalhamento.ShouldBe(99);
+        resposta.MaxFalhasConsecutivasDetalhamento.ShouldBe(2);
+        resposta.MaxFalhasConsecutivasDesdobramento.ShouldBe(2);
+        resposta.MaxItensParalelos.ShouldBe(10);
+        resposta.CodigosSondagem.ShouldNotBeEmpty();
+        resposta.ValidadeDiasProcessamento.ShouldBe(7);
+        resposta.CircuitBreakerLimiarErroPercent.ShouldBe(50);
+        resposta.CircuitBreakerJanelaAvaliacaoSegundos.ShouldBe(60);
+        resposta.CircuitBreakerPausaSegundos.ShouldBe(300);
+        resposta.CircuitBreakerAmostraMinima.ShouldBe(10);
+        resposta.Ativo.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Given_NenhumaConfiguracaoAtiva_Should_RetornarNotFoundError()
+    {
+        // Arrange
+        _repository
+            .Setup(r => r.ObterAtivaAsync())
+            .ReturnsAsync((ConfiguracaoCrawler?)null);
+
+        // Act
+        Result<ConfiguracaoCrawlerResponse> resultado = await _sut.ObterConfiguracaoAtualAsync();
+
+        // Assert
+        resultado.IsFailed.ShouldBeTrue();
+        resultado.Errors.OfType<NotFoundError>().ShouldNotBeEmpty();
+    }
+
+    [Fact]
+    public async Task Given_RequestValido_Should_AtualizarConfiguracaoCompleta()
+    {
+        // Arrange
+        var configuracao = ConfiguracaoCrawler.CriarPadrao();
+        configuracao.SetId("config-123");
+
+        _repository
+            .Setup(r => r.ObterAtivaAsync())
+            .ReturnsAsync(configuracao);
+
+        var request = new AtualizarConfiguracaoCrawlerRequest
+        {
+            CronSchedule = "0 3 * * *",
+            LimiteRequisicoesPorSegundo = 20,
+            OrcamentoDiario = 60000,
+            TamanheLoteCertificado = 300,
+            PausaLoteSegundos = 10,
+            TamanheLoteMongo = 100,
+            MaxTentativas = 5,
+            LimiteParadaAntecipada = 12,
+            MaxDesdobramento = 30,
+            MaxDetalhamento = 50,
+            MaxFalhasConsecutivasDetalhamento = 4,
+            MaxFalhasConsecutivasDesdobramento = 4,
+            MaxItensParalelos = 15,
+            CodigosSondagem = new List<string> { "01.01.01", "07.02.01" },
+            ValidadeDiasProcessamento = 14,
+            CircuitBreakerLimiarErroPercent = 70,
+            CircuitBreakerJanelaAvaliacaoSegundos = 120,
+            CircuitBreakerPausaSegundos = 600,
+            CircuitBreakerAmostraMinima = 20,
+            Ativo = false
+        };
+
+        // Act
+        Result<ConfiguracaoCrawlerResponse> resultado = await _sut.AtualizarConfiguracaoAsync(request);
+
+        // Assert
+        resultado.IsSuccess.ShouldBeTrue();
+
+        ConfiguracaoCrawlerResponse resposta = resultado.Value;
+        resposta.CronSchedule.ShouldBe("0 3 * * *");
+        resposta.LimiteRequisicoesPorSegundo.ShouldBe(20);
+        resposta.OrcamentoDiario.ShouldBe(60000);
+        resposta.TamanheLoteCertificado.ShouldBe(300);
+        resposta.PausaLoteSegundos.ShouldBe(10);
+        resposta.TamanheLoteMongo.ShouldBe(100);
+        resposta.MaxTentativas.ShouldBe(5);
+        resposta.LimiteParadaAntecipada.ShouldBe(12);
+        resposta.MaxDesdobramento.ShouldBe(30);
+        resposta.MaxDetalhamento.ShouldBe(50);
+        resposta.MaxFalhasConsecutivasDetalhamento.ShouldBe(4);
+        resposta.MaxFalhasConsecutivasDesdobramento.ShouldBe(4);
+        resposta.MaxItensParalelos.ShouldBe(15);
+        resposta.CodigosSondagem.Count.ShouldBe(2);
+        resposta.ValidadeDiasProcessamento.ShouldBe(14);
+        resposta.CircuitBreakerLimiarErroPercent.ShouldBe(70);
+        resposta.CircuitBreakerJanelaAvaliacaoSegundos.ShouldBe(120);
+        resposta.CircuitBreakerPausaSegundos.ShouldBe(600);
+        resposta.CircuitBreakerAmostraMinima.ShouldBe(20);
+        resposta.Ativo.ShouldBeFalse();
+
+        _repository.Verify(r => r.AtualizarAsync(It.IsAny<ConfiguracaoCrawler>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Given_NenhumaConfiguracaoAtiva_AtualizarCompleto_Should_RetornarNotFoundError()
+    {
+        // Arrange
+        _repository
+            .Setup(r => r.ObterAtivaAsync())
+            .ReturnsAsync((ConfiguracaoCrawler?)null);
+
+        var request = new AtualizarConfiguracaoCrawlerRequest
+        {
+            CronSchedule = "0 3 * * *",
+            LimiteRequisicoesPorSegundo = 20,
+            OrcamentoDiario = 60000,
+            TamanheLoteCertificado = 300,
+            PausaLoteSegundos = 10,
+            TamanheLoteMongo = 100,
+            MaxTentativas = 5,
+            LimiteParadaAntecipada = 12,
+            MaxDesdobramento = 30,
+            MaxDetalhamento = 50,
+            MaxFalhasConsecutivasDetalhamento = 4,
+            MaxFalhasConsecutivasDesdobramento = 4,
+            MaxItensParalelos = 15,
+            CodigosSondagem = new List<string> { "01.01.01" },
+            ValidadeDiasProcessamento = 14,
+            CircuitBreakerLimiarErroPercent = 70,
+            CircuitBreakerJanelaAvaliacaoSegundos = 120,
+            CircuitBreakerPausaSegundos = 600,
+            CircuitBreakerAmostraMinima = 20,
+            Ativo = false
+        };
+
+        // Act
+        Result<ConfiguracaoCrawlerResponse> resultado = await _sut.AtualizarConfiguracaoAsync(request);
+
+        // Assert
+        resultado.IsFailed.ShouldBeTrue();
+        resultado.Errors.OfType<NotFoundError>().ShouldNotBeEmpty();
+
+        _repository.Verify(r => r.AtualizarAsync(It.IsAny<ConfiguracaoCrawler>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Given_RequestParcialValido_Should_AtualizarApenasCamposInformados()
+    {
+        // Arrange
+        var configuracao = ConfiguracaoCrawler.CriarPadrao();
+        configuracao.SetId("config-parcial");
+
+        _repository
+            .Setup(r => r.ObterAtivaAsync())
+            .ReturnsAsync(configuracao);
+
+        var request = new AtualizarParcialConfiguracaoCrawlerRequest
+        {
+            CronSchedule = "0 4 * * *",
+            MaxTentativas = 7
+        };
+
+        // Act
+        Result<ConfiguracaoCrawlerResponse> resultado = await _sut.AtualizarParcialmenteAsync(request);
+
+        // Assert
+        resultado.IsSuccess.ShouldBeTrue();
+
+        ConfiguracaoCrawlerResponse resposta = resultado.Value;
+
+        // Campos alterados
+        resposta.CronSchedule.ShouldBe("0 4 * * *");
+        resposta.MaxTentativas.ShouldBe(7);
+
+        // Campos inalterados (valores padrão)
+        resposta.LimiteRequisicoesPorSegundo.ShouldBe(15);
+        resposta.OrcamentoDiario.ShouldBe(50000);
+        resposta.TamanheLoteCertificado.ShouldBe(200);
+        resposta.PausaLoteSegundos.ShouldBe(5);
+        resposta.TamanheLoteMongo.ShouldBe(50);
+        resposta.LimiteParadaAntecipada.ShouldBe(9);
+        resposta.MaxDesdobramento.ShouldBe(20);
+        resposta.MaxDetalhamento.ShouldBe(99);
+        resposta.MaxFalhasConsecutivasDetalhamento.ShouldBe(2);
+        resposta.MaxFalhasConsecutivasDesdobramento.ShouldBe(2);
+        resposta.MaxItensParalelos.ShouldBe(10);
+        resposta.ValidadeDiasProcessamento.ShouldBe(7);
+        resposta.CircuitBreakerLimiarErroPercent.ShouldBe(50);
+        resposta.CircuitBreakerJanelaAvaliacaoSegundos.ShouldBe(60);
+        resposta.CircuitBreakerPausaSegundos.ShouldBe(300);
+        resposta.CircuitBreakerAmostraMinima.ShouldBe(10);
+        resposta.Ativo.ShouldBeTrue();
+
+        _repository.Verify(r => r.AtualizarAsync(It.IsAny<ConfiguracaoCrawler>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Given_NenhumaConfiguracaoAtiva_AtualizarParcial_Should_RetornarNotFoundError()
+    {
+        // Arrange
+        _repository
+            .Setup(r => r.ObterAtivaAsync())
+            .ReturnsAsync((ConfiguracaoCrawler?)null);
+
+        var request = new AtualizarParcialConfiguracaoCrawlerRequest
+        {
+            CronSchedule = "0 4 * * *"
+        };
+
+        // Act
+        Result<ConfiguracaoCrawlerResponse> resultado = await _sut.AtualizarParcialmenteAsync(request);
+
+        // Assert
+        resultado.IsFailed.ShouldBeTrue();
+        resultado.Errors.OfType<NotFoundError>().ShouldNotBeEmpty();
+
+        _repository.Verify(r => r.AtualizarAsync(It.IsAny<ConfiguracaoCrawler>()), Times.Never);
+    }
+}

--- a/backend/MapaTributario/tests/MapaTributario.Tests.Unit/ConfiguracaoCrawlerAppServiceTests.cs
+++ b/backend/MapaTributario/tests/MapaTributario.Tests.Unit/ConfiguracaoCrawlerAppServiceTests.cs
@@ -29,7 +29,7 @@ public class ConfiguracaoCrawlerAppServiceTests
         configuracao.SetId("test-id");
 
         _repository
-            .Setup(r => r.ObterAtivaAsync())
+            .Setup(r => r.ObterAtualAsync())
             .ReturnsAsync(configuracao);
 
         // Act
@@ -43,9 +43,9 @@ public class ConfiguracaoCrawlerAppServiceTests
         resposta.CronSchedule.ShouldBe("0 2 * * *");
         resposta.LimiteRequisicoesPorSegundo.ShouldBe(15);
         resposta.OrcamentoDiario.ShouldBe(50000);
-        resposta.TamanheLoteCertificado.ShouldBe(200);
+        resposta.TamanhoLoteCertificado.ShouldBe(200);
         resposta.PausaLoteSegundos.ShouldBe(5);
-        resposta.TamanheLoteMongo.ShouldBe(50);
+        resposta.TamanhoLoteMongo.ShouldBe(50);
         resposta.MaxTentativas.ShouldBe(3);
         resposta.LimiteParadaAntecipada.ShouldBe(9);
         resposta.MaxDesdobramento.ShouldBe(20);
@@ -67,7 +67,7 @@ public class ConfiguracaoCrawlerAppServiceTests
     {
         // Arrange
         _repository
-            .Setup(r => r.ObterAtivaAsync())
+            .Setup(r => r.ObterAtualAsync())
             .ReturnsAsync((ConfiguracaoCrawler?)null);
 
         // Act
@@ -86,7 +86,7 @@ public class ConfiguracaoCrawlerAppServiceTests
         configuracao.SetId("config-123");
 
         _repository
-            .Setup(r => r.ObterAtivaAsync())
+            .Setup(r => r.ObterAtualAsync())
             .ReturnsAsync(configuracao);
 
         var request = new AtualizarConfiguracaoCrawlerRequest
@@ -94,9 +94,9 @@ public class ConfiguracaoCrawlerAppServiceTests
             CronSchedule = "0 3 * * *",
             LimiteRequisicoesPorSegundo = 20,
             OrcamentoDiario = 60000,
-            TamanheLoteCertificado = 300,
+            TamanhoLoteCertificado = 300,
             PausaLoteSegundos = 10,
-            TamanheLoteMongo = 100,
+            TamanhoLoteMongo = 100,
             MaxTentativas = 5,
             LimiteParadaAntecipada = 12,
             MaxDesdobramento = 30,
@@ -123,9 +123,9 @@ public class ConfiguracaoCrawlerAppServiceTests
         resposta.CronSchedule.ShouldBe("0 3 * * *");
         resposta.LimiteRequisicoesPorSegundo.ShouldBe(20);
         resposta.OrcamentoDiario.ShouldBe(60000);
-        resposta.TamanheLoteCertificado.ShouldBe(300);
+        resposta.TamanhoLoteCertificado.ShouldBe(300);
         resposta.PausaLoteSegundos.ShouldBe(10);
-        resposta.TamanheLoteMongo.ShouldBe(100);
+        resposta.TamanhoLoteMongo.ShouldBe(100);
         resposta.MaxTentativas.ShouldBe(5);
         resposta.LimiteParadaAntecipada.ShouldBe(12);
         resposta.MaxDesdobramento.ShouldBe(30);
@@ -149,7 +149,7 @@ public class ConfiguracaoCrawlerAppServiceTests
     {
         // Arrange
         _repository
-            .Setup(r => r.ObterAtivaAsync())
+            .Setup(r => r.ObterAtualAsync())
             .ReturnsAsync((ConfiguracaoCrawler?)null);
 
         var request = new AtualizarConfiguracaoCrawlerRequest
@@ -157,9 +157,9 @@ public class ConfiguracaoCrawlerAppServiceTests
             CronSchedule = "0 3 * * *",
             LimiteRequisicoesPorSegundo = 20,
             OrcamentoDiario = 60000,
-            TamanheLoteCertificado = 300,
+            TamanhoLoteCertificado = 300,
             PausaLoteSegundos = 10,
-            TamanheLoteMongo = 100,
+            TamanhoLoteMongo = 100,
             MaxTentativas = 5,
             LimiteParadaAntecipada = 12,
             MaxDesdobramento = 30,
@@ -194,7 +194,7 @@ public class ConfiguracaoCrawlerAppServiceTests
         configuracao.SetId("config-parcial");
 
         _repository
-            .Setup(r => r.ObterAtivaAsync())
+            .Setup(r => r.ObterAtualAsync())
             .ReturnsAsync(configuracao);
 
         var request = new AtualizarParcialConfiguracaoCrawlerRequest
@@ -218,9 +218,9 @@ public class ConfiguracaoCrawlerAppServiceTests
         // Campos inalterados (valores padrão)
         resposta.LimiteRequisicoesPorSegundo.ShouldBe(15);
         resposta.OrcamentoDiario.ShouldBe(50000);
-        resposta.TamanheLoteCertificado.ShouldBe(200);
+        resposta.TamanhoLoteCertificado.ShouldBe(200);
         resposta.PausaLoteSegundos.ShouldBe(5);
-        resposta.TamanheLoteMongo.ShouldBe(50);
+        resposta.TamanhoLoteMongo.ShouldBe(50);
         resposta.LimiteParadaAntecipada.ShouldBe(9);
         resposta.MaxDesdobramento.ShouldBe(20);
         resposta.MaxDetalhamento.ShouldBe(99);
@@ -242,7 +242,7 @@ public class ConfiguracaoCrawlerAppServiceTests
     {
         // Arrange
         _repository
-            .Setup(r => r.ObterAtivaAsync())
+            .Setup(r => r.ObterAtualAsync())
             .ReturnsAsync((ConfiguracaoCrawler?)null);
 
         var request = new AtualizarParcialConfiguracaoCrawlerRequest

--- a/backend/MapaTributario/tests/MapaTributario.Tests.Unit/ConfiguracaoCrawlerTests.cs
+++ b/backend/MapaTributario/tests/MapaTributario.Tests.Unit/ConfiguracaoCrawlerTests.cs
@@ -77,4 +77,92 @@ public class ConfiguracaoCrawlerTests
         // Assert
         configuracao.Id.ShouldBe("abc123");
     }
+
+    [Fact]
+    public void Atualizar_Deve_AtualizarTodasPropriedades()
+    {
+        // Arrange
+        ConfiguracaoCrawler configuracao = ConfiguracaoCrawler.CriarPadrao();
+        var novosCodigosSondagem = new List<string> { "01.01.01", "07.02.01" };
+
+        // Act
+        configuracao.Atualizar(
+            cronSchedule: "0 5 * * *",
+            limiteRequisicoesPorSegundo: 25,
+            orcamentoDiario: 80000,
+            tamanheLoteCertificado: 400,
+            pausaLoteSegundos: 15,
+            tamanheLoteMongo: 75,
+            maxTentativas: 6,
+            limiteParadaAntecipada: 15,
+            maxDesdobramento: 40,
+            maxDetalhamento: 120,
+            maxFalhasConsecutivasDetalhamento: 5,
+            maxFalhasConsecutivasDesdobramento: 5,
+            maxItensParalelos: 20,
+            codigosSondagem: novosCodigosSondagem,
+            validadeDiasProcessamento: 10,
+            circuitBreakerLimiarErroPercent: 80,
+            circuitBreakerJanelaAvaliacaoSegundos: 90,
+            circuitBreakerPausaSegundos: 500,
+            circuitBreakerAmostraMinima: 15,
+            ativo: false);
+
+        // Assert
+        configuracao.CronSchedule.ShouldBe("0 5 * * *");
+        configuracao.LimiteRequisicoesPorSegundo.ShouldBe(25);
+        configuracao.OrcamentoDiario.ShouldBe(80000);
+        configuracao.TamanheLoteCertificado.ShouldBe(400);
+        configuracao.PausaLoteSegundos.ShouldBe(15);
+        configuracao.TamanheLoteMongo.ShouldBe(75);
+        configuracao.MaxTentativas.ShouldBe(6);
+        configuracao.LimiteParadaAntecipada.ShouldBe(15);
+        configuracao.MaxDesdobramento.ShouldBe(40);
+        configuracao.MaxDetalhamento.ShouldBe(120);
+        configuracao.MaxFalhasConsecutivasDetalhamento.ShouldBe(5);
+        configuracao.MaxFalhasConsecutivasDesdobramento.ShouldBe(5);
+        configuracao.MaxItensParalelos.ShouldBe(20);
+        configuracao.CodigosSondagem.ShouldBe(novosCodigosSondagem);
+        configuracao.ValidadeDiasProcessamento.ShouldBe(10);
+        configuracao.CircuitBreakerLimiarErroPercent.ShouldBe(80);
+        configuracao.CircuitBreakerJanelaAvaliacaoSegundos.ShouldBe(90);
+        configuracao.CircuitBreakerPausaSegundos.ShouldBe(500);
+        configuracao.CircuitBreakerAmostraMinima.ShouldBe(15);
+        configuracao.Ativo.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void AtualizarParcial_Deve_AtualizarApenasCamposInformados()
+    {
+        // Arrange
+        ConfiguracaoCrawler configuracao = ConfiguracaoCrawler.CriarPadrao();
+
+        // Act
+        configuracao.AtualizarParcial(
+            cronSchedule: "0 4 * * *",
+            maxTentativas: 7);
+
+        // Assert — campos alterados
+        configuracao.CronSchedule.ShouldBe("0 4 * * *");
+        configuracao.MaxTentativas.ShouldBe(7);
+
+        // Assert — campos inalterados (valores padrão)
+        configuracao.LimiteRequisicoesPorSegundo.ShouldBe(15);
+        configuracao.OrcamentoDiario.ShouldBe(50000);
+        configuracao.TamanheLoteCertificado.ShouldBe(200);
+        configuracao.PausaLoteSegundos.ShouldBe(5);
+        configuracao.TamanheLoteMongo.ShouldBe(50);
+        configuracao.LimiteParadaAntecipada.ShouldBe(9);
+        configuracao.MaxDesdobramento.ShouldBe(20);
+        configuracao.MaxDetalhamento.ShouldBe(99);
+        configuracao.MaxFalhasConsecutivasDetalhamento.ShouldBe(2);
+        configuracao.MaxFalhasConsecutivasDesdobramento.ShouldBe(2);
+        configuracao.MaxItensParalelos.ShouldBe(10);
+        configuracao.ValidadeDiasProcessamento.ShouldBe(7);
+        configuracao.CircuitBreakerLimiarErroPercent.ShouldBe(50);
+        configuracao.CircuitBreakerJanelaAvaliacaoSegundos.ShouldBe(60);
+        configuracao.CircuitBreakerPausaSegundos.ShouldBe(300);
+        configuracao.CircuitBreakerAmostraMinima.ShouldBe(10);
+        configuracao.Ativo.ShouldBeTrue();
+    }
 }

--- a/backend/MapaTributario/tests/MapaTributario.Tests.Unit/ConfiguracaoCrawlerTests.cs
+++ b/backend/MapaTributario/tests/MapaTributario.Tests.Unit/ConfiguracaoCrawlerTests.cs
@@ -90,9 +90,9 @@ public class ConfiguracaoCrawlerTests
             cronSchedule: "0 5 * * *",
             limiteRequisicoesPorSegundo: 25,
             orcamentoDiario: 80000,
-            tamanheLoteCertificado: 400,
+            tamanhoLoteCertificado: 400,
             pausaLoteSegundos: 15,
-            tamanheLoteMongo: 75,
+            tamanhoLoteMongo: 75,
             maxTentativas: 6,
             limiteParadaAntecipada: 15,
             maxDesdobramento: 40,
@@ -112,9 +112,9 @@ public class ConfiguracaoCrawlerTests
         configuracao.CronSchedule.ShouldBe("0 5 * * *");
         configuracao.LimiteRequisicoesPorSegundo.ShouldBe(25);
         configuracao.OrcamentoDiario.ShouldBe(80000);
-        configuracao.TamanheLoteCertificado.ShouldBe(400);
+        configuracao.TamanhoLoteCertificado.ShouldBe(400);
         configuracao.PausaLoteSegundos.ShouldBe(15);
-        configuracao.TamanheLoteMongo.ShouldBe(75);
+        configuracao.TamanhoLoteMongo.ShouldBe(75);
         configuracao.MaxTentativas.ShouldBe(6);
         configuracao.LimiteParadaAntecipada.ShouldBe(15);
         configuracao.MaxDesdobramento.ShouldBe(40);
@@ -149,9 +149,9 @@ public class ConfiguracaoCrawlerTests
         // Assert — campos inalterados (valores padrão)
         configuracao.LimiteRequisicoesPorSegundo.ShouldBe(15);
         configuracao.OrcamentoDiario.ShouldBe(50000);
-        configuracao.TamanheLoteCertificado.ShouldBe(200);
+        configuracao.TamanhoLoteCertificado.ShouldBe(200);
         configuracao.PausaLoteSegundos.ShouldBe(5);
-        configuracao.TamanheLoteMongo.ShouldBe(50);
+        configuracao.TamanhoLoteMongo.ShouldBe(50);
         configuracao.LimiteParadaAntecipada.ShouldBe(9);
         configuracao.MaxDesdobramento.ShouldBe(20);
         configuracao.MaxDetalhamento.ShouldBe(99);


### PR DESCRIPTION
## Summary

Implementa a PBI #31 — endpoints REST CRUD para administração da configuração do crawler, permitindo consultar e alterar configurações sem editar appsettings.json.

Closes #31

## Endpoints

| Método | Rota | Descrição |
|--------|------|-----------|
| GET | `/api/v1/crawler/configuracao` | Retorna a configuração ativa |
| PUT | `/api/v1/crawler/configuracao` | Atualiza a configuração completa |
| PATCH | `/api/v1/crawler/configuracao` | Atualiza campos específicos |

Todos protegidos por `[Authorize(Roles = "Admin")]` (herdado do CrawlerController).

## Changes

### Novos arquivos
- **`ConfiguracaoCrawlerAppService.cs`** — Serviço de aplicação (Scoped) com FluentResults
- **`IConfiguracaoCrawlerAppService.cs`** — Interface do serviço
- **`ConfiguracaoCrawlerResponse.cs`** — DTO de resposta com todas as propriedades
- **`AtualizarConfiguracaoCrawlerRequest.cs`** — DTO para atualização completa (PUT)
- **`AtualizarParcialConfiguracaoCrawlerRequest.cs`** — DTO para atualização parcial (PATCH, todos nullable)
- **`AtualizarConfiguracaoCrawlerRequestValidator.cs`** — FluentValidation para PUT
- **`AtualizarParcialConfiguracaoCrawlerRequestValidator.cs`** — FluentValidation para PATCH (valida apenas campos não-null)
- **`ConfiguracaoCrawlerAppServiceTests.cs`** — 6 testes unitários para o serviço

### Arquivos modificados
- **`ConfiguracaoCrawler.cs`** — Adicionados métodos `Atualizar()` (completo) e `AtualizarParcial()` (parcial)
- **`CrawlerController.cs`** — 3 novos endpoints GET/PUT/PATCH + injeção de `IConfiguracaoCrawlerAppService`
- **`ApplicationServiceExtensions.cs`** — Registro do `ConfiguracaoCrawlerAppService` como Scoped
- **`ConfiguracaoCrawlerTests.cs`** — 2 novos testes para os métodos Atualizar

## Validações

- CronSchedule: não vazio + formato válido (5 partes)
- Valores numéricos: > 0 com limites máximos configurados
- CodigosSondagem: não vazio + formato XX.XX.XX
- CircuitBreakerLimiarErroPercent: entre 1 e 100
- Mensagens de erro em português

## Test Results

- **227 testes passando** (8 novos + 219 existentes)
- 0 falhas, 0 warnings