### PR TITLE
fix: corrigir progresso de UF marcado como concluido antes de processar convenios

### DIFF
--- a/backend/MapaTributario/src/MapaTributario.API/Application/Crawler/Contracts/StatusCrawlerResponse.cs
+++ b/backend/MapaTributario/src/MapaTributario.API/Application/Crawler/Contracts/StatusCrawlerResponse.cs
@@ -27,6 +27,7 @@ public class ProgressoUfResponse
     public string Uf { get; set; } = null!;
     public string Status { get; set; } = null!;
     public int MunicipiosEncontrados { get; set; }
+    public int MunicipiosAtivos { get; set; }
     public DateTime? Inicio { get; set; }
     public DateTime? Fim { get; set; }
 }

--- a/backend/MapaTributario/src/MapaTributario.API/Application/Crawler/CrawlerService.cs
+++ b/backend/MapaTributario/src/MapaTributario.API/Application/Crawler/CrawlerService.cs
@@ -219,7 +219,8 @@ public class CrawlerService : ICrawlerService
     {
         _logger.LogInformation("Phase 1: Discovering municipalities via convenio endpoint");
 
-        List<Municipio> todos = new();
+        List<Municipio> todosAtivos = new();
+        bool interrompidoPorProtecao = false;
 
         IEnumerable<string> ufsParaProcessar = filtroUfs is { Count: > 0 }
             ? filtroUfs.Select(u => u.ToUpperInvariant()).Where(u => UfsBrasil.Todas.Contains(u))
@@ -232,89 +233,103 @@ public class CrawlerService : ICrawlerService
 
         foreach (string uf in ufsParaProcessar)
         {
-            execucao.IniciarProcessamentoUf(uf);
-
-            IReadOnlyList<Municipio> porUf = await _municipioRepository.GetByUfAsync(uf);
-            todos.AddRange(porUf);
-
-            int municipiosUf = porUf.Count;
-            execucao.FinalizarProcessamentoUf(uf, municipiosUf);
-        }
-
-        // Filtrar por capital quando solicitado:
-        // filtroCapital = true  → somente capitais estaduais
-        // filtroCapital = false → somente municípios que NÃO são capitais
-        // filtroCapital = null  → sem filtro (todos os municípios)
-        if (filtroCapital.HasValue)
-        {
-            int antesDoFiltro = todos.Count;
-            todos = todos.Where(m => m.EhCapital == filtroCapital.Value).ToList();
-
-            _logger.LogInformation(
-                "Filtro por capital aplicado (somenteCapitais={Filtro}): {Antes} → {Depois} municípios",
-                filtroCapital.Value, antesDoFiltro, todos.Count);
-        }
-
-        // Priorizar capitais: processar todas as capitais primeiro (de todas as UFs),
-        // depois os demais municípios em ordem alfabética por UF e nome.
-        List<Municipio> todosOrdenados = todos
-            .OrderByDescending(m => m.EhCapital)
-            .ThenBy(m => m.SiglaEstado)
-            .ThenBy(m => m.Nome)
-            .ToList();
-
-        _logger.LogInformation(
-            "Processing order: {Capitais} capitais first, then {Demais} remaining municipalities",
-            todosOrdenados.Count(m => m.EhCapital),
-            todosOrdenados.Count(m => !m.EhCapital));
-
-        List<Municipio> ativos = new();
-
-        foreach (Municipio municipio in todosOrdenados)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            if (_certificateProtection.ShouldHalt || _certificateProtection.BudgetExhausted)
+            // Se a proteção de certificado interrompeu, UFs restantes ficam "Pendente"
+            if (interrompidoPorProtecao)
             {
                 break;
             }
 
-            try
+            execucao.IniciarProcessamentoUf(uf);
+
+            IReadOnlyList<Municipio> porUf = await _municipioRepository.GetByUfAsync(uf);
+            int municipiosEncontrados = porUf.Count;
+
+            // Filtrar por capital quando solicitado
+            List<Municipio> municipiosParaVerificar = porUf.ToList();
+            if (filtroCapital.HasValue)
             {
-                await _rateLimiter.WaitAsync(cancellationToken);
-                await _circuitBreaker.WaitIfOpenAsync(cancellationToken);
+                municipiosParaVerificar = municipiosParaVerificar
+                    .Where(m => m.EhCapital == filtroCapital.Value).ToList();
+            }
 
-                Stopwatch sw = Stopwatch.StartNew();
-                ConvenioNfseResponse? convenio =
-                    await _nfseApiClient.GetConvenioAsync(municipio.CodigoIbge, cancellationToken);
-                sw.Stop();
+            // Priorizar capitais dentro da UF
+            municipiosParaVerificar = municipiosParaVerificar
+                .OrderByDescending(m => m.EhCapital)
+                .ThenBy(m => m.Nome)
+                .ToList();
 
-                _certificateProtection.OnResponseReceived(200, sw.Elapsed.TotalSeconds);
-                _circuitBreaker.RecordSuccess();
-                await _certificateProtection.OnItemProcessedAsync(cancellationToken);
+            List<Municipio> ativosUf = new();
+            int errosUf = 0;
+            int verificadosUf = 0;
+            bool ufInterrompida = false;
 
-                if (convenio is not null && convenio.Ativo)
+            foreach (Municipio municipio in municipiosParaVerificar)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (_certificateProtection.ShouldHalt || _certificateProtection.BudgetExhausted)
                 {
-                    ativos.Add(municipio);
+                    ufInterrompida = true;
+                    interrompidoPorProtecao = true;
+                    break;
+                }
+
+                verificadosUf++;
+
+                try
+                {
+                    await _rateLimiter.WaitAsync(cancellationToken);
+                    await _circuitBreaker.WaitIfOpenAsync(cancellationToken);
+
+                    Stopwatch sw = Stopwatch.StartNew();
+                    ConvenioNfseResponse? convenio =
+                        await _nfseApiClient.GetConvenioAsync(municipio.CodigoIbge, cancellationToken);
+                    sw.Stop();
+
+                    _certificateProtection.OnResponseReceived(200, sw.Elapsed.TotalSeconds);
+                    _circuitBreaker.RecordSuccess();
+                    await _certificateProtection.OnItemProcessedAsync(cancellationToken);
+
+                    if (convenio is not null && convenio.Ativo)
+                    {
+                        ativosUf.Add(municipio);
+                    }
+                }
+                catch (HttpRequestException ex)
+                {
+                    int statusCode = (int)(ex.StatusCode ?? System.Net.HttpStatusCode.InternalServerError);
+                    _certificateProtection.OnResponseReceived(statusCode, 0);
+                    _circuitBreaker.RecordFailure();
+                    await _certificateProtection.OnItemProcessedAsync(cancellationToken);
+                    errosUf++;
+
+                    _logger.LogWarning(
+                        "Failed to check convenio for municipality {CodigoIbge}: {Message}",
+                        municipio.CodigoIbge, ex.Message);
                 }
             }
-            catch (HttpRequestException ex)
-            {
-                int statusCode = (int)(ex.StatusCode ?? System.Net.HttpStatusCode.InternalServerError);
-                _certificateProtection.OnResponseReceived(statusCode, 0);
-                _circuitBreaker.RecordFailure();
-                await _certificateProtection.OnItemProcessedAsync(cancellationToken);
 
-                _logger.LogWarning(
-                    "Failed to check convenio for municipality {CodigoIbge}: {Message}",
-                    municipio.CodigoIbge, ex.Message);
+            // Determinar status da UF com base no resultado real
+            if (ufInterrompida)
+            {
+                execucao.InterromperProcessamentoUf(uf, municipiosEncontrados, ativosUf.Count);
             }
+            else if (verificadosUf > 0 && errosUf == verificadosUf)
+            {
+                execucao.FalharProcessamentoUf(uf, municipiosEncontrados);
+            }
+            else
+            {
+                execucao.FinalizarProcessamentoUf(uf, municipiosEncontrados, ativosUf.Count);
+            }
+
+            todosAtivos.AddRange(ativosUf);
         }
 
-        _logger.LogInformation("Phase 1 complete. {Active}/{Total} municipalities active",
-            ativos.Count, todos.Count);
+        _logger.LogInformation("Phase 1 complete. {Active} active municipalities found across all UFs",
+            todosAtivos.Count);
 
-        return ativos;
+        return todosAtivos;
     }
 
     internal async Task<List<Municipio>> FaseProbeAsync(

--- a/backend/MapaTributario/src/MapaTributario.API/Application/Crawler/CrawlerService.cs
+++ b/backend/MapaTributario/src/MapaTributario.API/Application/Crawler/CrawlerService.cs
@@ -278,8 +278,9 @@ public class CrawlerService : ICrawlerService
 
                 try
                 {
-                    await _rateLimiter.WaitAsync(cancellationToken);
-                    await _circuitBreaker.WaitIfOpenAsync(cancellationToken);
+                    await Task.WhenAll(
+                        _rateLimiter.WaitAsync(cancellationToken),
+                        _circuitBreaker.WaitIfOpenAsync(cancellationToken));
 
                     Stopwatch sw = Stopwatch.StartNew();
                     ConvenioNfseResponse? convenio =
@@ -358,8 +359,9 @@ public class CrawlerService : ICrawlerService
 
                 try
                 {
-                    await _rateLimiter.WaitAsync(cancellationToken);
-                    await _circuitBreaker.WaitIfOpenAsync(cancellationToken);
+                    await Task.WhenAll(
+                        _rateLimiter.WaitAsync(cancellationToken),
+                        _circuitBreaker.WaitIfOpenAsync(cancellationToken));
 
                     Stopwatch sw = Stopwatch.StartNew();
                     // NfseApiClient.FormatarCodigoServico adds ".000" desdobramento automatically
@@ -604,8 +606,9 @@ public class CrawlerService : ICrawlerService
         System.Collections.Concurrent.ConcurrentDictionary<string, int> consecutiveMissesByGroup,
         CancellationToken cancellationToken)
     {
-        await _rateLimiter.WaitAsync(cancellationToken);
-        await _circuitBreaker.WaitIfOpenAsync(cancellationToken);
+                    await Task.WhenAll(
+                        _rateLimiter.WaitAsync(cancellationToken),
+                        _circuitBreaker.WaitIfOpenAsync(cancellationToken));
 
         Stopwatch sw = Stopwatch.StartNew();
         AliquotaNfseResponse? result =
@@ -690,8 +693,9 @@ public class CrawlerService : ICrawlerService
             string codigoDetalhamento = $"{itemPart}.{subitemPart}.{det:D2}";
             string codigoCompleto = $"{codigoDetalhamento}.000";
 
-            await _rateLimiter.WaitAsync(cancellationToken);
-            await _circuitBreaker.WaitIfOpenAsync(cancellationToken);
+            await Task.WhenAll(
+                _rateLimiter.WaitAsync(cancellationToken),
+                _circuitBreaker.WaitIfOpenAsync(cancellationToken));
 
             Stopwatch sw = Stopwatch.StartNew();
             AliquotaNfseResponse? result =
@@ -739,8 +743,9 @@ public class CrawlerService : ICrawlerService
 
                 string codigoDesdobramento = $"{codigoDetalhamento}.{desdobramento:D3}";
 
-                await _rateLimiter.WaitAsync(cancellationToken);
-                await _circuitBreaker.WaitIfOpenAsync(cancellationToken);
+                await Task.WhenAll(
+                    _rateLimiter.WaitAsync(cancellationToken),
+                    _circuitBreaker.WaitIfOpenAsync(cancellationToken));
 
                 Stopwatch swDesdobramento = Stopwatch.StartNew();
                 AliquotaNfseResponse? resultDesdobramento =

--- a/backend/MapaTributario/src/MapaTributario.API/Controllers/CrawlerController.cs
+++ b/backend/MapaTributario/src/MapaTributario.API/Controllers/CrawlerController.cs
@@ -225,8 +225,9 @@ public class CrawlerController : ControllerBase
                 kvp => new ProgressoUfResponse
                 {
                     Uf = kvp.Value.Uf,
-                    Status = kvp.Value.Status,
+                    Status = kvp.Value.Status.ToString(),
                     MunicipiosEncontrados = kvp.Value.MunicipiosEncontrados,
+                    MunicipiosAtivos = kvp.Value.MunicipiosAtivos,
                     Inicio = kvp.Value.Inicio,
                     Fim = kvp.Value.Fim
                 })

--- a/backend/MapaTributario/src/MapaTributario.API/Domain/Entities/ExecucaoCrawler.cs
+++ b/backend/MapaTributario/src/MapaTributario.API/Domain/Entities/ExecucaoCrawler.cs
@@ -81,13 +81,13 @@ public class ExecucaoCrawler
             ProgressoUfs[UfAtual] = new ProgressoUf
             {
                 Uf = UfAtual,
-                Status = "EmAndamento",
+                Status = StatusProgressoUf.EmAndamento,
                 Inicio = DateTime.UtcNow
             };
         }
         else
         {
-            ProgressoUfs[UfAtual].Status = "EmAndamento";
+            ProgressoUfs[UfAtual].Status = StatusProgressoUf.EmAndamento;
             ProgressoUfs[UfAtual].Inicio = DateTime.UtcNow;
         }
     }
@@ -97,7 +97,7 @@ public class ExecucaoCrawler
         string ufNormalizada = uf.ToUpperInvariant();
         if (ProgressoUfs.ContainsKey(ufNormalizada))
         {
-            ProgressoUfs[ufNormalizada].Status = "Concluido";
+            ProgressoUfs[ufNormalizada].Status = StatusProgressoUf.Concluido;
             ProgressoUfs[ufNormalizada].MunicipiosEncontrados = municipiosEncontrados;
             ProgressoUfs[ufNormalizada].MunicipiosAtivos = municipiosAtivos;
             ProgressoUfs[ufNormalizada].Fim = DateTime.UtcNow;
@@ -115,7 +115,7 @@ public class ExecucaoCrawler
         string ufNormalizada = uf.ToUpperInvariant();
         if (ProgressoUfs.ContainsKey(ufNormalizada))
         {
-            ProgressoUfs[ufNormalizada].Status = "Falha";
+            ProgressoUfs[ufNormalizada].Status = StatusProgressoUf.Falha;
             ProgressoUfs[ufNormalizada].MunicipiosEncontrados = municipiosEncontrados;
             ProgressoUfs[ufNormalizada].MunicipiosAtivos = 0;
             ProgressoUfs[ufNormalizada].Fim = DateTime.UtcNow;
@@ -132,7 +132,7 @@ public class ExecucaoCrawler
         string ufNormalizada = uf.ToUpperInvariant();
         if (ProgressoUfs.ContainsKey(ufNormalizada))
         {
-            ProgressoUfs[ufNormalizada].Status = "Interrompido";
+            ProgressoUfs[ufNormalizada].Status = StatusProgressoUf.Interrompido;
             ProgressoUfs[ufNormalizada].MunicipiosEncontrados = municipiosEncontrados;
             ProgressoUfs[ufNormalizada].MunicipiosAtivos = municipiosAtivosAteAgora;
             ProgressoUfs[ufNormalizada].Fim = DateTime.UtcNow;
@@ -162,9 +162,18 @@ public enum TipoExecucao
 public class ProgressoUf
 {
     public string Uf { get; set; } = null!;
-    public string Status { get; set; } = "Pendente";
+    public StatusProgressoUf Status { get; set; } = StatusProgressoUf.Pendente;
     public int MunicipiosEncontrados { get; set; }
     public int MunicipiosAtivos { get; set; }
     public DateTime? Inicio { get; set; }
     public DateTime? Fim { get; set; }
+}
+
+public enum StatusProgressoUf
+{
+    Pendente,
+    EmAndamento,
+    Concluido,
+    Falha,
+    Interrompido
 }

--- a/backend/MapaTributario/src/MapaTributario.API/Domain/Entities/ExecucaoCrawler.cs
+++ b/backend/MapaTributario/src/MapaTributario.API/Domain/Entities/ExecucaoCrawler.cs
@@ -92,17 +92,52 @@ public class ExecucaoCrawler
         }
     }
 
-    public void FinalizarProcessamentoUf(string uf, int municipiosEncontrados)
+    public void FinalizarProcessamentoUf(string uf, int municipiosEncontrados, int municipiosAtivos)
     {
         string ufNormalizada = uf.ToUpperInvariant();
         if (ProgressoUfs.ContainsKey(ufNormalizada))
         {
             ProgressoUfs[ufNormalizada].Status = "Concluido";
             ProgressoUfs[ufNormalizada].MunicipiosEncontrados = municipiosEncontrados;
+            ProgressoUfs[ufNormalizada].MunicipiosAtivos = municipiosAtivos;
             ProgressoUfs[ufNormalizada].Fim = DateTime.UtcNow;
         }
 
         // Limpar UfAtual se era esta UF
+        if (UfAtual == ufNormalizada)
+        {
+            UfAtual = null;
+        }
+    }
+
+    public void FalharProcessamentoUf(string uf, int municipiosEncontrados)
+    {
+        string ufNormalizada = uf.ToUpperInvariant();
+        if (ProgressoUfs.ContainsKey(ufNormalizada))
+        {
+            ProgressoUfs[ufNormalizada].Status = "Falha";
+            ProgressoUfs[ufNormalizada].MunicipiosEncontrados = municipiosEncontrados;
+            ProgressoUfs[ufNormalizada].MunicipiosAtivos = 0;
+            ProgressoUfs[ufNormalizada].Fim = DateTime.UtcNow;
+        }
+
+        if (UfAtual == ufNormalizada)
+        {
+            UfAtual = null;
+        }
+    }
+
+    public void InterromperProcessamentoUf(string uf, int municipiosEncontrados, int municipiosAtivosAteAgora)
+    {
+        string ufNormalizada = uf.ToUpperInvariant();
+        if (ProgressoUfs.ContainsKey(ufNormalizada))
+        {
+            ProgressoUfs[ufNormalizada].Status = "Interrompido";
+            ProgressoUfs[ufNormalizada].MunicipiosEncontrados = municipiosEncontrados;
+            ProgressoUfs[ufNormalizada].MunicipiosAtivos = municipiosAtivosAteAgora;
+            ProgressoUfs[ufNormalizada].Fim = DateTime.UtcNow;
+        }
+
         if (UfAtual == ufNormalizada)
         {
             UfAtual = null;
@@ -129,6 +164,7 @@ public class ProgressoUf
     public string Uf { get; set; } = null!;
     public string Status { get; set; } = "Pendente";
     public int MunicipiosEncontrados { get; set; }
+    public int MunicipiosAtivos { get; set; }
     public DateTime? Inicio { get; set; }
     public DateTime? Fim { get; set; }
 }

--- a/backend/MapaTributario/src/MapaTributario.API/infrastructure/Repository/Mongo/CrawlerMongoMappings.cs
+++ b/backend/MapaTributario/src/MapaTributario.API/infrastructure/Repository/Mongo/CrawlerMongoMappings.cs
@@ -59,8 +59,10 @@ public static class CrawlerMongoMappings
         {
             cm.AutoMap();
             cm.MapMember(p => p.Uf).SetElementName("uf");
-            cm.MapMember(p => p.Status).SetElementName("status");
+            cm.MapMember(p => p.Status).SetElementName("status")
+                .SetSerializer(new EnumSerializer<StatusProgressoUf>(BsonType.String));
             cm.MapMember(p => p.MunicipiosEncontrados).SetElementName("municipiosEncontrados");
+            cm.MapMember(p => p.MunicipiosAtivos).SetElementName("municipiosAtivos");
             cm.MapMember(p => p.Inicio).SetElementName("inicio");
             cm.MapMember(p => p.Fim).SetElementName("fim");
             cm.SetIgnoreExtraElements(true);

--- a/backend/MapaTributario/tests/MapaTributario.Tests.Unit/CrawlerServiceTests.cs
+++ b/backend/MapaTributario/tests/MapaTributario.Tests.Unit/CrawlerServiceTests.cs
@@ -641,12 +641,10 @@ public class CrawlerServiceTests
         // Assert
         resultado.Count.ShouldBe(4);
 
-        // Capitais devem vir primeiro (ordenadas por UF)
+        // Dentro de cada UF, capitais vêm primeiro (MG é processado antes de SP)
         resultado[0].CodigoIbge.ShouldBe("3106200"); // BH (capital MG)
-        resultado[1].CodigoIbge.ShouldBe("3550308"); // SP (capital SP)
-
-        // Depois os demais (ordenados por UF e nome)
-        resultado[2].CodigoIbge.ShouldBe("3170206"); // Uberlândia (interior MG — MG vem antes de SP)
+        resultado[1].CodigoIbge.ShouldBe("3170206"); // Uberlândia (interior MG)
+        resultado[2].CodigoIbge.ShouldBe("3550308"); // São Paulo (capital SP)
         resultado[3].CodigoIbge.ShouldBe("3509502"); // Campinas (interior SP)
     }
 

--- a/backend/MapaTributario/tests/MapaTributario.Tests.Unit/CrawlerServiceTests.cs
+++ b/backend/MapaTributario/tests/MapaTributario.Tests.Unit/CrawlerServiceTests.cs
@@ -966,7 +966,7 @@ public class CrawlerServiceTests
         // Assert — nenhum município ativo retornado
         resultado.Count.ShouldBe(0);
         execucao.ProgressoUfs.ShouldContainKey("SE");
-        execucao.ProgressoUfs["SE"].Status.ShouldBe("Falha");
+        execucao.ProgressoUfs["SE"].Status.ShouldBe(StatusProgressoUf.Falha);
         execucao.ProgressoUfs["SE"].MunicipiosEncontrados.ShouldBe(2);
         execucao.ProgressoUfs["SE"].MunicipiosAtivos.ShouldBe(0);
     }
@@ -1005,7 +1005,7 @@ public class CrawlerServiceTests
 
         // Assert — RO deve estar "Interrompido" (halt ativou após 1º município)
         execucao.ProgressoUfs.ShouldContainKey("RO");
-        execucao.ProgressoUfs["RO"].Status.ShouldBe("Interrompido");
+        execucao.ProgressoUfs["RO"].Status.ShouldBe(StatusProgressoUf.Interrompido);
         execucao.ProgressoUfs["RO"].MunicipiosEncontrados.ShouldBe(3);
         execucao.ProgressoUfs["RO"].MunicipiosAtivos.ShouldBe(1); // Apenas Alta Floresta verificada
 
@@ -1033,7 +1033,7 @@ public class CrawlerServiceTests
 
         // Assert
         resultado.Count.ShouldBe(0);
-        execucao.ProgressoUfs["DF"].Status.ShouldBe("Concluido");
+        execucao.ProgressoUfs["DF"].Status.ShouldBe(StatusProgressoUf.Concluido);
         execucao.ProgressoUfs["DF"].MunicipiosEncontrados.ShouldBe(1);
         execucao.ProgressoUfs["DF"].MunicipiosAtivos.ShouldBe(0);
     }
@@ -1059,7 +1059,7 @@ public class CrawlerServiceTests
 
         // Assert
         resultado.Count.ShouldBe(2);
-        execucao.ProgressoUfs["SE"].Status.ShouldBe("Concluido");
+        execucao.ProgressoUfs["SE"].Status.ShouldBe(StatusProgressoUf.Concluido);
         execucao.ProgressoUfs["SE"].MunicipiosEncontrados.ShouldBe(2);
         execucao.ProgressoUfs["SE"].MunicipiosAtivos.ShouldBe(2);
     }
@@ -1094,7 +1094,7 @@ public class CrawlerServiceTests
         // Assert — apenas Aracaju é ativo
         resultado.Count.ShouldBe(1);
         resultado[0].CodigoIbge.ShouldBe("2800308");
-        execucao.ProgressoUfs["SE"].Status.ShouldBe("Concluido"); // Não é "Falha" porque nem todos falharam
+        execucao.ProgressoUfs["SE"].Status.ShouldBe(StatusProgressoUf.Concluido); // Não é "Falha" porque nem todos falharam
         execucao.ProgressoUfs["SE"].MunicipiosEncontrados.ShouldBe(3);
         execucao.ProgressoUfs["SE"].MunicipiosAtivos.ShouldBe(1);
     }
@@ -1134,11 +1134,11 @@ public class CrawlerServiceTests
 
         // Assert
         // AC: processa Rio Branco antes do halt → Concluido
-        execucao.ProgressoUfs["AC"].Status.ShouldBe("Concluido");
+        execucao.ProgressoUfs["AC"].Status.ShouldBe(StatusProgressoUf.Concluido);
         execucao.ProgressoUfs["AC"].MunicipiosAtivos.ShouldBe(1);
 
         // AL: halt já ativo ao entrar no loop → interrompida sem verificar nenhum município
-        execucao.ProgressoUfs["AL"].Status.ShouldBe("Interrompido");
+        execucao.ProgressoUfs["AL"].Status.ShouldBe(StatusProgressoUf.Interrompido);
         execucao.ProgressoUfs["AL"].MunicipiosAtivos.ShouldBe(0);
 
         // AM: não foi iniciada — não deve existir no dicionário

--- a/backend/MapaTributario/tests/MapaTributario.Tests.Unit/CrawlerServiceTests.cs
+++ b/backend/MapaTributario/tests/MapaTributario.Tests.Unit/CrawlerServiceTests.cs
@@ -943,4 +943,209 @@ public class CrawlerServiceTests
     }
 
     #endregion
+
+    #region ProgressoUf — Regression Tests (fix-progresso-uf-prematuro)
+
+    [Fact]
+    public async Task Dado_TodasChamadasConvenioFalham_ProgressoUfDeveSerFalha()
+    {
+        // Arrange — todas as chamadas GetConvenioAsync falham com HttpRequestException
+        Municipio mun1 = Municipio.Create("2800308", "Aracaju", "SE");
+        Municipio mun2 = Municipio.Create("2802106", "Itabaiana", "SE");
+
+        _municipioRepo.Setup(r => r.GetByUfAsync("SE"))
+            .ReturnsAsync(new List<Municipio> { mun1, mun2 });
+        _municipioRepo.Setup(r => r.GetByUfAsync(It.Is<string>(s => s != "SE")))
+            .ReturnsAsync(new List<Municipio>());
+
+        _nfseClient.Setup(c => c.GetConvenioAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("SSL certificate error", null, System.Net.HttpStatusCode.InternalServerError));
+
+        // Act
+        ExecucaoCrawler execucao = ExecucaoCrawler.Create(TipoExecucao.Manual);
+        List<Municipio> resultado = await _sut.FaseConvenioAsync(execucao, new[] { "SE" }, null, CancellationToken.None);
+
+        // Assert — nenhum município ativo retornado
+        resultado.Count.ShouldBe(0);
+        execucao.ProgressoUfs.ShouldContainKey("SE");
+        execucao.ProgressoUfs["SE"].Status.ShouldBe("Falha");
+        execucao.ProgressoUfs["SE"].MunicipiosEncontrados.ShouldBe(2);
+        execucao.ProgressoUfs["SE"].MunicipiosAtivos.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task Dado_CertificateProtectionInterrompe_UfAtualDeveSerInterrompido()
+    {
+        // Arrange — RO tem 3 municípios; halt ativa após o 1º ser verificado
+        Municipio mun1 = Municipio.Create("1100015", "Alta Floresta D'Oeste", "RO");
+        Municipio mun2 = Municipio.Create("1100205", "Porto Velho", "RO");
+        Municipio mun3 = Municipio.Create("1100379", "Vilhena", "RO");
+        Municipio munAM = Municipio.Create("1302603", "Manaus", "AM");
+
+        _municipioRepo.Setup(r => r.GetByUfAsync("RO"))
+            .ReturnsAsync(new List<Municipio> { mun1, mun2, mun3 });
+        _municipioRepo.Setup(r => r.GetByUfAsync("AM"))
+            .ReturnsAsync(new List<Municipio> { munAM });
+        _municipioRepo.Setup(r => r.GetByUfAsync(It.Is<string>(s => s != "RO" && s != "AM")))
+            .ReturnsAsync(new List<Municipio>());
+
+        // Todos os municípios retornam convênio ativo
+        int chamadas = 0;
+        _nfseClient.Setup(c => c.GetConvenioAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback(() => chamadas++)
+            .ReturnsAsync(CriarConvenioAtivo());
+
+        // ShouldHalt ativa após a 1ª chamada de convênio ser concluída
+        // O check acontece ANTES de cada município no loop, então:
+        // - mun1 (Alta Floresta): check=false (chamadas=0), processa, chamadas→1
+        // - mun2 (Porto Velho): check=true (chamadas=1) → break → interrompido
+        _certProtection.Setup(c => c.ShouldHalt).Returns(() => chamadas >= 1);
+
+        // Act
+        ExecucaoCrawler execucao = ExecucaoCrawler.Create(TipoExecucao.Manual);
+        await _sut.FaseConvenioAsync(execucao, new[] { "RO", "AM" }, null, CancellationToken.None);
+
+        // Assert — RO deve estar "Interrompido" (halt ativou após 1º município)
+        execucao.ProgressoUfs.ShouldContainKey("RO");
+        execucao.ProgressoUfs["RO"].Status.ShouldBe("Interrompido");
+        execucao.ProgressoUfs["RO"].MunicipiosEncontrados.ShouldBe(3);
+        execucao.ProgressoUfs["RO"].MunicipiosAtivos.ShouldBe(1); // Apenas Alta Floresta verificada
+
+        // AM não deve ter sido iniciada (break no loop externo)
+        execucao.ProgressoUfs.ShouldNotContainKey("AM");
+    }
+
+    [Fact]
+    public async Task Dado_ZeroMunicipiosAtivos_ProgressoUfDeveRefletirContagens()
+    {
+        // Arrange — município existe no banco mas convênio retorna null (inativo)
+        Municipio mun1 = Municipio.Create("5300108", "Brasília", "DF");
+
+        _municipioRepo.Setup(r => r.GetByUfAsync("DF"))
+            .ReturnsAsync(new List<Municipio> { mun1 });
+        _municipioRepo.Setup(r => r.GetByUfAsync(It.Is<string>(s => s != "DF")))
+            .ReturnsAsync(new List<Municipio>());
+
+        _nfseClient.Setup(c => c.GetConvenioAsync("5300108", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ConvenioNfseResponse?)null);
+
+        // Act
+        ExecucaoCrawler execucao = ExecucaoCrawler.Create(TipoExecucao.Manual);
+        List<Municipio> resultado = await _sut.FaseConvenioAsync(execucao, new[] { "DF" }, null, CancellationToken.None);
+
+        // Assert
+        resultado.Count.ShouldBe(0);
+        execucao.ProgressoUfs["DF"].Status.ShouldBe("Concluido");
+        execucao.ProgressoUfs["DF"].MunicipiosEncontrados.ShouldBe(1);
+        execucao.ProgressoUfs["DF"].MunicipiosAtivos.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task Dado_ConvenioAtivo_ProgressoUfDeveSerConcluidoComAtivos()
+    {
+        // Arrange — 2 municípios, ambos com convênio ativo
+        Municipio mun1 = Municipio.Create("2800308", "Aracaju", "SE");
+        Municipio mun2 = Municipio.Create("2802106", "Itabaiana", "SE");
+
+        _municipioRepo.Setup(r => r.GetByUfAsync("SE"))
+            .ReturnsAsync(new List<Municipio> { mun1, mun2 });
+        _municipioRepo.Setup(r => r.GetByUfAsync(It.Is<string>(s => s != "SE")))
+            .ReturnsAsync(new List<Municipio>());
+
+        _nfseClient.Setup(c => c.GetConvenioAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CriarConvenioAtivo());
+
+        // Act
+        ExecucaoCrawler execucao = ExecucaoCrawler.Create(TipoExecucao.Manual);
+        List<Municipio> resultado = await _sut.FaseConvenioAsync(execucao, new[] { "SE" }, null, CancellationToken.None);
+
+        // Assert
+        resultado.Count.ShouldBe(2);
+        execucao.ProgressoUfs["SE"].Status.ShouldBe("Concluido");
+        execucao.ProgressoUfs["SE"].MunicipiosEncontrados.ShouldBe(2);
+        execucao.ProgressoUfs["SE"].MunicipiosAtivos.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task Dado_FalhasParciais_ProgressoUfDeveRefletirAtivos()
+    {
+        // Arrange — 3 municípios: 1 ativo, 1 inativo (null), 1 falha (exception)
+        Municipio mun1 = Municipio.Create("2800308", "Aracaju", "SE");
+        Municipio mun2 = Municipio.Create("2802106", "Itabaiana", "SE");
+        Municipio mun3 = Municipio.Create("2803500", "Lagarto", "SE");
+
+        _municipioRepo.Setup(r => r.GetByUfAsync("SE"))
+            .ReturnsAsync(new List<Municipio> { mun1, mun2, mun3 });
+        _municipioRepo.Setup(r => r.GetByUfAsync(It.Is<string>(s => s != "SE")))
+            .ReturnsAsync(new List<Municipio>());
+
+        // mun1: convênio ativo
+        _nfseClient.Setup(c => c.GetConvenioAsync("2800308", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CriarConvenioAtivo());
+        // mun2: sem convênio
+        _nfseClient.Setup(c => c.GetConvenioAsync("2802106", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ConvenioNfseResponse?)null);
+        // mun3: erro HTTP
+        _nfseClient.Setup(c => c.GetConvenioAsync("2803500", It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("Timeout", null, System.Net.HttpStatusCode.RequestTimeout));
+
+        // Act
+        ExecucaoCrawler execucao = ExecucaoCrawler.Create(TipoExecucao.Manual);
+        List<Municipio> resultado = await _sut.FaseConvenioAsync(execucao, new[] { "SE" }, null, CancellationToken.None);
+
+        // Assert — apenas Aracaju é ativo
+        resultado.Count.ShouldBe(1);
+        resultado[0].CodigoIbge.ShouldBe("2800308");
+        execucao.ProgressoUfs["SE"].Status.ShouldBe("Concluido"); // Não é "Falha" porque nem todos falharam
+        execucao.ProgressoUfs["SE"].MunicipiosEncontrados.ShouldBe(3);
+        execucao.ProgressoUfs["SE"].MunicipiosAtivos.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task Dado_InterrupcaoNoMeio_UfsNaoIniciadasDevemFicarPendente()
+    {
+        // Arrange — 3 UFs: AC, AL, AM. Halt ativa após processar AC (1 município).
+        // AL inicia mas é interrompida imediatamente, AM nunca é iniciada.
+        Municipio munAC = Municipio.Create("1200401", "Rio Branco", "AC");
+        Municipio munAL1 = Municipio.Create("2700102", "Água Branca", "AL");
+        Municipio munAL2 = Municipio.Create("2704302", "Maceió", "AL");
+        Municipio munAM = Municipio.Create("1302603", "Manaus", "AM");
+
+        _municipioRepo.Setup(r => r.GetByUfAsync("AC"))
+            .ReturnsAsync(new List<Municipio> { munAC });
+        _municipioRepo.Setup(r => r.GetByUfAsync("AL"))
+            .ReturnsAsync(new List<Municipio> { munAL1, munAL2 });
+        _municipioRepo.Setup(r => r.GetByUfAsync("AM"))
+            .ReturnsAsync(new List<Municipio> { munAM });
+        _municipioRepo.Setup(r => r.GetByUfAsync(It.Is<string>(s => s != "AC" && s != "AL" && s != "AM")))
+            .ReturnsAsync(new List<Municipio>());
+
+        // Todos retornam convênio ativo
+        int chamadas = 0;
+        _nfseClient.Setup(c => c.GetConvenioAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback(() => chamadas++)
+            .ReturnsAsync(CriarConvenioAtivo());
+
+        // Halt ativa após 1ª chamada (AC processa Rio Branco, chamadas→1).
+        // AL: ao iniciar o loop de municípios, ShouldHalt já é true → break imediato → interrompida
+        _certProtection.Setup(c => c.ShouldHalt).Returns(() => chamadas >= 1);
+
+        // Act
+        ExecucaoCrawler execucao = ExecucaoCrawler.Create(TipoExecucao.Manual);
+        await _sut.FaseConvenioAsync(execucao, new[] { "AC", "AL", "AM" }, null, CancellationToken.None);
+
+        // Assert
+        // AC: processa Rio Branco antes do halt → Concluido
+        execucao.ProgressoUfs["AC"].Status.ShouldBe("Concluido");
+        execucao.ProgressoUfs["AC"].MunicipiosAtivos.ShouldBe(1);
+
+        // AL: halt já ativo ao entrar no loop → interrompida sem verificar nenhum município
+        execucao.ProgressoUfs["AL"].Status.ShouldBe("Interrompido");
+        execucao.ProgressoUfs["AL"].MunicipiosAtivos.ShouldBe(0);
+
+        // AM: não foi iniciada — não deve existir no dicionário
+        execucao.ProgressoUfs.ShouldNotContainKey("AM");
+    }
+
+    #endregion
 }

--- a/backend/MapaTributario/tests/MapaTributario.Tests.Unit/ExecucaoCrawlerTests.cs
+++ b/backend/MapaTributario/tests/MapaTributario.Tests.Unit/ExecucaoCrawlerTests.cs
@@ -92,4 +92,72 @@ public class ExecucaoCrawlerTests
         execucao.SetId("abc123");
         execucao.Id.ShouldBe("abc123");
     }
+
+    [Fact]
+    public void FinalizarProcessamentoUf_AtualizaStatusMunicipiosEncontradosEAtivos()
+    {
+        ExecucaoCrawler execucao = ExecucaoCrawler.Create(TipoExecucao.Manual);
+        execucao.IniciarProcessamentoUf("SP");
+
+        execucao.FinalizarProcessamentoUf("SP", municipiosEncontrados: 100, municipiosAtivos: 42);
+
+        execucao.ProgressoUfs["SP"].Status.ShouldBe("Concluido");
+        execucao.ProgressoUfs["SP"].MunicipiosEncontrados.ShouldBe(100);
+        execucao.ProgressoUfs["SP"].MunicipiosAtivos.ShouldBe(42);
+        execucao.ProgressoUfs["SP"].Fim.ShouldNotBeNull();
+        execucao.UfAtual.ShouldBeNull();
+    }
+
+    [Fact]
+    public void FalharProcessamentoUf_MarcaStatusFalhaComMunicipiosAtivosZero()
+    {
+        ExecucaoCrawler execucao = ExecucaoCrawler.Create(TipoExecucao.Manual);
+        execucao.IniciarProcessamentoUf("RJ");
+
+        execucao.FalharProcessamentoUf("RJ", municipiosEncontrados: 50);
+
+        execucao.ProgressoUfs["RJ"].Status.ShouldBe("Falha");
+        execucao.ProgressoUfs["RJ"].MunicipiosEncontrados.ShouldBe(50);
+        execucao.ProgressoUfs["RJ"].MunicipiosAtivos.ShouldBe(0);
+        execucao.ProgressoUfs["RJ"].Fim.ShouldNotBeNull();
+        execucao.UfAtual.ShouldBeNull();
+    }
+
+    [Fact]
+    public void InterromperProcessamentoUf_MarcaStatusInterrompidoComAtivosAteAgora()
+    {
+        ExecucaoCrawler execucao = ExecucaoCrawler.Create(TipoExecucao.Manual);
+        execucao.IniciarProcessamentoUf("MG");
+
+        execucao.InterromperProcessamentoUf("MG", municipiosEncontrados: 80, municipiosAtivosAteAgora: 15);
+
+        execucao.ProgressoUfs["MG"].Status.ShouldBe("Interrompido");
+        execucao.ProgressoUfs["MG"].MunicipiosEncontrados.ShouldBe(80);
+        execucao.ProgressoUfs["MG"].MunicipiosAtivos.ShouldBe(15);
+        execucao.ProgressoUfs["MG"].Fim.ShouldNotBeNull();
+        execucao.UfAtual.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ProgressoUf_StatusInicial_DeveSePendente()
+    {
+        ProgressoUf progresso = new();
+
+        progresso.Status.ShouldBe("Pendente");
+        progresso.MunicipiosEncontrados.ShouldBe(0);
+        progresso.MunicipiosAtivos.ShouldBe(0);
+    }
+
+    [Fact]
+    public void IniciarProcessamentoUf_CriaProgressoComStatusEmAndamento()
+    {
+        ExecucaoCrawler execucao = ExecucaoCrawler.Create(TipoExecucao.Manual);
+
+        execucao.IniciarProcessamentoUf("SE");
+
+        execucao.ProgressoUfs.ShouldContainKey("SE");
+        execucao.ProgressoUfs["SE"].Status.ShouldBe("EmAndamento");
+        execucao.ProgressoUfs["SE"].Inicio.ShouldNotBeNull();
+        execucao.UfAtual.ShouldBe("SE");
+    }
 }

--- a/backend/MapaTributario/tests/MapaTributario.Tests.Unit/ExecucaoCrawlerTests.cs
+++ b/backend/MapaTributario/tests/MapaTributario.Tests.Unit/ExecucaoCrawlerTests.cs
@@ -101,7 +101,7 @@ public class ExecucaoCrawlerTests
 
         execucao.FinalizarProcessamentoUf("SP", municipiosEncontrados: 100, municipiosAtivos: 42);
 
-        execucao.ProgressoUfs["SP"].Status.ShouldBe("Concluido");
+        execucao.ProgressoUfs["SP"].Status.ShouldBe(StatusProgressoUf.Concluido);
         execucao.ProgressoUfs["SP"].MunicipiosEncontrados.ShouldBe(100);
         execucao.ProgressoUfs["SP"].MunicipiosAtivos.ShouldBe(42);
         execucao.ProgressoUfs["SP"].Fim.ShouldNotBeNull();
@@ -116,7 +116,7 @@ public class ExecucaoCrawlerTests
 
         execucao.FalharProcessamentoUf("RJ", municipiosEncontrados: 50);
 
-        execucao.ProgressoUfs["RJ"].Status.ShouldBe("Falha");
+        execucao.ProgressoUfs["RJ"].Status.ShouldBe(StatusProgressoUf.Falha);
         execucao.ProgressoUfs["RJ"].MunicipiosEncontrados.ShouldBe(50);
         execucao.ProgressoUfs["RJ"].MunicipiosAtivos.ShouldBe(0);
         execucao.ProgressoUfs["RJ"].Fim.ShouldNotBeNull();
@@ -131,7 +131,7 @@ public class ExecucaoCrawlerTests
 
         execucao.InterromperProcessamentoUf("MG", municipiosEncontrados: 80, municipiosAtivosAteAgora: 15);
 
-        execucao.ProgressoUfs["MG"].Status.ShouldBe("Interrompido");
+        execucao.ProgressoUfs["MG"].Status.ShouldBe(StatusProgressoUf.Interrompido);
         execucao.ProgressoUfs["MG"].MunicipiosEncontrados.ShouldBe(80);
         execucao.ProgressoUfs["MG"].MunicipiosAtivos.ShouldBe(15);
         execucao.ProgressoUfs["MG"].Fim.ShouldNotBeNull();
@@ -139,11 +139,11 @@ public class ExecucaoCrawlerTests
     }
 
     [Fact]
-    public void ProgressoUf_StatusInicial_DeveSePendente()
+    public void ProgressoUf_StatusInicial_DeveSerPendente()
     {
         ProgressoUf progresso = new();
 
-        progresso.Status.ShouldBe("Pendente");
+        progresso.Status.ShouldBe(StatusProgressoUf.Pendente);
         progresso.MunicipiosEncontrados.ShouldBe(0);
         progresso.MunicipiosAtivos.ShouldBe(0);
     }
@@ -156,7 +156,7 @@ public class ExecucaoCrawlerTests
         execucao.IniciarProcessamentoUf("SE");
 
         execucao.ProgressoUfs.ShouldContainKey("SE");
-        execucao.ProgressoUfs["SE"].Status.ShouldBe("EmAndamento");
+        execucao.ProgressoUfs["SE"].Status.ShouldBe(StatusProgressoUf.EmAndamento);
         execucao.ProgressoUfs["SE"].Inicio.ShouldNotBeNull();
         execucao.UfAtual.ShouldBe("SE");
     }

--- a/frontend/MapaTributario-ui/src/app/features/admin/crawler/models/crawler.models.ts
+++ b/frontend/MapaTributario-ui/src/app/features/admin/crawler/models/crawler.models.ts
@@ -19,6 +19,7 @@ export interface ProgressoUf {
   uf: string;
   status: string;
   municipiosEncontrados: number;
+  municipiosAtivos: number;
   inicio: string;
   fim: string | null;
 }

--- a/frontend/MapaTributario-ui/src/app/features/admin/crawler/status/crawler-status.component.html
+++ b/frontend/MapaTributario-ui/src/app/features/admin/crawler/status/crawler-status.component.html
@@ -98,6 +98,7 @@
                     </div>
                     <div class="progresso-uf-detalhes">
                       <span>Municípios: {{ progresso.municipiosEncontrados }}</span>
+                      <span>Ativos: {{ progresso.municipiosAtivos }}</span>
                       <span>Início: {{ progresso.inicio | date:'HH:mm:ss' }}</span>
                       @if (progresso.fim) {
                         <span>Fim: {{ progresso.fim | date:'HH:mm:ss' }}</span>

--- a/frontend/MapaTributario-ui/src/app/features/admin/crawler/status/crawler-status.component.ts
+++ b/frontend/MapaTributario-ui/src/app/features/admin/crawler/status/crawler-status.component.ts
@@ -139,6 +139,7 @@ export class CrawlerStatusComponent implements OnInit, OnDestroy {
       case 'concluido': return 'success';
       case 'emandamento': return 'info';
       case 'falha': return 'danger';
+      case 'interrompido': return 'warn';
       default: return 'secondary';
     }
   }

--- a/openspec/changes/fix-progresso-uf-prematuro/.openspec.yaml
+++ b/openspec/changes/fix-progresso-uf-prematuro/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-02

--- a/openspec/changes/fix-progresso-uf-prematuro/design.md
+++ b/openspec/changes/fix-progresso-uf-prematuro/design.md
@@ -1,0 +1,74 @@
+## Context
+
+O `CrawlerService.FaseConvenioAsync` executa dois loops sequenciais:
+1. **Loop por UF**: percorre as 27 UFs, lê municípios do MongoDB local, e chama `FinalizarProcessamentoUf(uf, count)` — marcando a UF como "Concluido" com a contagem de municípios do banco.
+2. **Loop por município**: percorre todos os municípios coletados e chama a API externa `GetConvenioAsync` para verificar se são ativos.
+
+O problema é que o Loop 1 já marca todas as UFs como "Concluido" antes do Loop 2 iniciar. Se as chamadas de convênio falham (certificado inválido, CertificateProtection, CircuitBreaker), nenhum município é ativado, mas o `ProgressoUfs` já está salvo como concluído.
+
+Arquivos impactados:
+- `CrawlerService.cs` (linhas 214-318 — `FaseConvenioAsync`)
+- `ExecucaoCrawler.cs` (entidade de domínio)
+- `ProgressoUf` (classe embedded no `ExecucaoCrawler`)
+- `crawler-status.component.html` (template do frontend)
+- `crawler.models.ts` (modelos TypeScript)
+
+## Goals / Non-Goals
+
+**Goals:**
+- O `ProgressoUf` de cada UF deve refletir o resultado real das chamadas de convênio à API externa
+- Diferenciar "municípios encontrados no banco" de "municípios confirmados ativos via API"
+- UFs cujas chamadas falharam devem ter status "Falha"
+- UFs não processadas por interrupção (CertificateProtection) devem manter status "Pendente" ou ter status "Interrompido"
+- Testes de regressão devem provar o bug e validar o comportamento correto
+
+**Non-Goals:**
+- Não alterar o fluxo das Fases 2 (Probe) e 3 (ProcessarFila)
+- Não alterar a lógica de CertificateProtection ou CircuitBreaker em si
+- Não mudar a API de execução (`POST /api/v1/crawler/executar`)
+
+## Decisions
+
+### 1. Unificar o loop por UF com as chamadas de convênio
+
+**Decisão**: Reestruturar `FaseConvenioAsync` para agrupar as chamadas de convênio por UF dentro do mesmo loop. Cada UF é iniciada, tem seus municípios lidos do banco, cada município é verificado via convênio, e a UF é finalizada com o resultado real.
+
+**Alternativa considerada**: Manter os dois loops separados e atualizar o `ProgressoUf` após o Loop 2 com base na UF de cada município ativo. Rejeitada porque não capturaria corretamente UFs interrompidas (a informação de "qual UF estava sendo processada quando CertProtection interrompeu" se perderia).
+
+**Estrutura do novo loop**:
+```
+para cada UF:
+  1. IniciarProcessamentoUf(uf)
+  2. Ler municípios do banco → todos da UF
+  3. Aplicar filtro de capital (se houver)
+  4. Para cada município da UF:
+     - Verificar CertProtection.ShouldHalt / BudgetExhausted → se sim, marcar UF como "Interrompido" e sair
+     - Chamar GetConvenioAsync
+     - Se ativo, adicionar à lista
+  5. FinalizarProcessamentoUf(uf, encontrados, ativos)
+```
+
+### 2. Adicionar campo `MunicipiosAtivos` ao `ProgressoUf`
+
+**Decisão**: Manter `MunicipiosEncontrados` (contagem do banco local) e adicionar `MunicipiosAtivos` (contagem de municípios confirmados via API). Isso permite ao administrador entender "de X encontrados no banco, Y foram confirmados ativos".
+
+**Alternativa considerada**: Substituir `MunicipiosEncontrados` pelo valor real. Rejeitada porque a informação de "quantos existem no banco" é útil para diagnóstico.
+
+### 3. Novos status no `ProgressoUf`
+
+**Decisão**: Adicionar os status "Falha" e "Interrompido":
+- **"Falha"**: Todas as chamadas de convênio para a UF falharam com exceção (HttpRequestException)
+- **"Interrompido"**: O processamento foi interrompido por CertificateProtection antes de completar a UF
+- **"Concluido"**: Todas as chamadas de convênio da UF foram executadas (independentemente de quantos estão ativos)
+
+### 4. Ordenação: capitais primeiro dentro de cada UF
+
+**Decisão**: A priorização de capitais será mantida, mas agora ocorrerá dentro do loop por UF. Capitais de cada UF serão processadas antes dos demais municípios daquela UF, e entre UFs, a ordem alfabética será mantida.
+
+**Trade-off**: Na versão anterior, TODAS as capitais de todas as UFs eram processadas antes de qualquer município interior. Agora, dentro de cada UF as capitais vêm primeiro, mas a UF "AC" completa antes de "AL" começar. Isso é aceitável porque o progresso por UF fica mais preciso.
+
+## Risks / Trade-offs
+
+- **[Mudança de ordem de processamento]** → Capitais eram processadas todas juntas antes; agora são processadas por UF. Mitigação: a priorização de capitais dentro de cada UF é mantida; o comportamento da funcionalidade "Executar capitais primeiro" (`filtroCapital=true`) não é afetado.
+- **[Campo novo na response]** → `MunicipiosAtivos` é adicionado ao `ProgressoUf`. Mitigação: campo aditivo, não quebra clientes existentes. O frontend será atualizado para exibir.
+- **[Persistência intermediária]** → Antes, o `ProgressoUfs` era salvo uma vez após o Loop 1 completo. Agora, pode ser salvo após cada UF ou ao final de todas as UFs. Decisão: salvar ao final de todas as UFs (mesma frequência atual) para não aumentar writes no MongoDB.

--- a/openspec/changes/fix-progresso-uf-prematuro/proposal.md
+++ b/openspec/changes/fix-progresso-uf-prematuro/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+O crawler marca todas as UFs como "Concluído" com contagem de municípios antes de iniciar as chamadas à API externa de convênio. Quando as chamadas falham silenciosamente (certificado inválido, CertificateProtection, CircuitBreaker), a tela mostra 27/27 UFs concluídas com municípios contabilizados, mas o resumo da execução registra 0 municípios, 0 serviços, 0 processados. Isso gera divergência de informação e impede o administrador de identificar falhas.
+
+## What Changes
+
+- Corrigir o momento em que `FinalizarProcessamentoUf` é chamado: deve ocorrer após a verificação de convênio dos municípios daquela UF, não na leitura do banco local
+- Separar a contagem de municípios do banco local (`MunicipiosEncontrados`) da contagem de municípios confirmados via API (`MunicipiosAtivos`) no `ProgressoUf`
+- Adicionar status "Falha" e "Interrompido" ao `ProgressoUf` para refletir cenários de erro e interrupção por proteção de certificado
+- Quando `CertificateProtection.ShouldHalt` ou `BudgetExhausted` interrompe o processamento, as UFs não verificadas devem permanecer como "Pendente" ou ser marcadas como "Interrompido"
+- Adicionar testes de regressão que comprovem o bug e validem o comportamento correto
+- Atualizar o frontend para exibir `MunicipiosAtivos` nos cards de progresso por UF
+
+## Capabilities
+
+### New Capabilities
+
+_(nenhuma)_
+
+### Modified Capabilities
+
+- `data-crawler`: O requisito "Execution tracking" precisa ser atualizado para exigir que o progresso por UF reflita o resultado real das chamadas de convênio, não apenas a contagem de municípios no banco local. Novos cenários para UFs com falha e UFs interrompidas por proteção de certificado.
+
+## Impact
+
+- **Backend**: `CrawlerService.FaseConvenioAsync` — reestruturação do loop para rastrear progresso por UF durante as chamadas de convênio. `ExecucaoCrawler`/`ProgressoUf` — novo campo `MunicipiosAtivos`, novos status "Falha" e "Interrompido".
+- **Frontend**: `crawler-status.component.html` — exibir `MunicipiosAtivos` nos cards de progresso por UF.
+- **Testes**: Novos testes unitários em `CrawlerServiceTests` e `ExecucaoCrawlerTests` cobrindo cenários de falha silenciosa e interrupção por proteção de certificado.
+- **API**: O campo `municipiosAtivos` será adicionado ao `ProgressoUf` na response de `GET /api/v1/crawler/status`. Campo aditivo, sem breaking change.

--- a/openspec/changes/fix-progresso-uf-prematuro/specs/data-crawler/spec.md
+++ b/openspec/changes/fix-progresso-uf-prematuro/specs/data-crawler/spec.md
@@ -1,0 +1,36 @@
+## MODIFIED Requirements
+
+### Requirement: Execution tracking
+The worker SHALL record each execution cycle in the `execucoes_crawler` collection with: id, inicio, fim, status (em_andamento/concluido/falha_parcial/falha), tipo (agendado/manual), totalMunicipios, totalServicos, processados, erros, detalhesErro[]. The worker SHALL also track per-UF progress in `progressoUfs`, where each UF entry SHALL include: uf, status (Pendente/EmAndamento/Concluido/Falha/Interrompido), municipiosEncontrados (count from local database), municipiosAtivos (count confirmed via external API), inicio, fim. The per-UF status SHALL reflect the actual result of the external API calls for that UF, not merely the local database read.
+
+#### Scenario: Execution completed
+- **WHEN** all queue items are processed
+- **THEN** the execution record is updated with final counts and status
+
+#### Scenario: Execution status endpoint
+- **WHEN** an admin user (role Admin) calls `GET /api/v1/crawler/status`
+- **THEN** the system returns the latest execution record including per-UF progress with both municipiosEncontrados and municipiosAtivos
+
+#### Scenario: Execution history
+- **WHEN** an admin user (role Admin) calls `GET /api/v1/crawler/execucoes`
+- **THEN** the system returns the last 20 execution records
+
+#### Scenario: UF progress reflects actual API result
+- **WHEN** the worker verifies convenio for all municipalities of a UF and at least one is active
+- **THEN** the UF progress status SHALL be "Concluido" with municipiosAtivos reflecting the count of active municipalities
+
+#### Scenario: UF progress when all convenio calls fail
+- **WHEN** the worker attempts to verify convenio for all municipalities of a UF and ALL calls fail with HTTP errors
+- **THEN** the UF progress status SHALL be "Falha" with municipiosAtivos = 0
+
+#### Scenario: UF progress when no municipalities are active
+- **WHEN** the worker verifies convenio for all municipalities of a UF and none are active (all return inactive or null)
+- **THEN** the UF progress status SHALL be "Concluido" with municipiosAtivos = 0
+
+#### Scenario: UF progress when processing is interrupted
+- **WHEN** the CertificateProtection halts or budget is exhausted during processing of a UF
+- **THEN** the current UF progress status SHALL be "Interrompido" and remaining unprocessed UFs SHALL remain "Pendente"
+
+#### Scenario: UF progress municipiosEncontrados reflects local database
+- **WHEN** the worker reads municipalities from the local database for a UF
+- **THEN** municipiosEncontrados SHALL reflect the count of municipalities found in the local database, regardless of API call results

--- a/openspec/changes/fix-progresso-uf-prematuro/tasks.md
+++ b/openspec/changes/fix-progresso-uf-prematuro/tasks.md
@@ -1,0 +1,31 @@
+## 1. Domínio — ProgressoUf e ExecucaoCrawler
+
+- [x] 1.1 Adicionar propriedade `MunicipiosAtivos` (int) à classe `ProgressoUf`
+- [x] 1.2 Adicionar suporte aos status "Falha" e "Interrompido" no `ProgressoUf`
+- [x] 1.3 Alterar `FinalizarProcessamentoUf` para receber `municipiosEncontrados` e `municipiosAtivos` separados
+- [x] 1.4 Criar método `InterromperProcessamentoUf(string uf)` em `ExecucaoCrawler` para marcar UF como "Interrompido"
+- [x] 1.5 Criar método `FalharProcessamentoUf(string uf, int municipiosEncontrados)` em `ExecucaoCrawler` para marcar UF como "Falha"
+
+## 2. CrawlerService — Reestruturação do FaseConvenioAsync
+
+- [x] 2.1 Reestruturar `FaseConvenioAsync` para unificar o loop por UF: ler municípios do banco e verificar convênio dentro do mesmo loop por UF
+- [x] 2.2 Chamar `FinalizarProcessamentoUf` com contagens reais (encontrados + ativos) após as chamadas de convênio da UF
+- [x] 2.3 Chamar `InterromperProcessamentoUf` quando CertificateProtection.ShouldHalt ou BudgetExhausted interrompe durante o processamento de uma UF
+- [x] 2.4 Chamar `FalharProcessamentoUf` quando todas as chamadas de convênio de uma UF falham com exceção
+- [x] 2.5 Manter UFs não processadas como "Pendente" quando o loop é interrompido antes de chegar a elas
+
+## 3. Frontend — Cards de progresso por UF
+
+- [x] 3.1 Adicionar campo `municipiosAtivos` ao modelo TypeScript `ProgressoUf` em `crawler.models.ts`
+- [x] 3.2 Atualizar template `crawler-status.component.html` para exibir `municipiosAtivos` nos cards de UF
+- [x] 3.3 Adicionar tratamento visual para os novos status "Falha" e "Interrompido" nos cards de UF
+
+## 4. Testes unitários
+
+- [x] 4.1 Teste: `Dado_TodasChamadasConvenioFalham_ProgressoUfDeveSerFalha` — quando todas as chamadas GetConvenioAsync falham com HttpRequestException, o ProgressoUf da UF deve ter status "Falha" e MunicipiosAtivos = 0
+- [x] 4.2 Teste: `Dado_CertificateProtectionInterrompe_UfAtualDeveSerInterrompido` — quando CertificateProtection.ShouldHalt é true durante o processamento de uma UF, a UF atual deve ter status "Interrompido" e UFs restantes devem ficar "Pendente"
+- [x] 4.3 Teste: `Dado_ZeroMunicipiosAtivos_ProgressoUfDeveRefletirContagens` — quando nenhum município da UF tem convênio ativo, MunicipiosEncontrados deve refletir o banco e MunicipiosAtivos deve ser 0
+- [x] 4.4 Teste: `Dado_ConvenioAtivo_ProgressoUfDeveSerConcluido` — quando há municípios ativos, status deve ser "Concluido" e MunicipiosAtivos > 0
+- [x] 4.5 Teste: `Dado_FalhasParciais_ProgressoUfDeveRefletirAtivos` — quando parte dos municípios falham e parte têm convênio ativo, MunicipiosAtivos reflete apenas os ativos
+- [x] 4.6 Teste: `Dado_InterrupcaoNoMeio_UfsNaoIniciadasDevemFicarPendente` — quando CertProtection interrompe no meio, UFs posteriores devem permanecer "Pendente"
+- [x] 4.7 Testes de `ExecucaoCrawler`: testar `InterromperProcessamentoUf` e `FalharProcessamentoUf` na entidade


### PR DESCRIPTION
## Resumo

Corrige bug onde o crawler marcava todas as 27 UFs como "Concluído" com contagem de municípios **antes** de executar qualquer chamada à API externa de convênio. Quando as chamadas falhavam silenciosamente (certificado inválido, CircuitBreaker, CertificateProtection), o frontend exibia 27/27 UFs concluídas mas 0 municípios processados — uma exibição contraditória e enganosa.

## Causa raiz

Em `CrawlerService.FaseConvenioAsync`, havia dois loops separados:
1. **Loop 1** iterava as UFs lendo municípios do MongoDB local e imediatamente chamava `FinalizarProcessamentoUf(uf, count)` marcando cada UF como "Concluído"
2. **Loop 2** iterava todos os municípios chamando a API externa `GetConvenioAsync`

Quando o Loop 2 falhava, o progresso das UFs já estava persistido como concluído.

## Solução

- **Unificar loop** em `FaseConvenioAsync`: ler municípios do banco e verificar convênio na mesma iteração por UF
- `FinalizarProcessamentoUf` só é chamado após resultado real das chamadas de API
- Adicionado `MunicipiosAtivos` ao `ProgressoUf` para distinguir municípios encontrados no banco vs municípios com convênio ativo
- Adicionados métodos `FalharProcessamentoUf` (status "Falha") e `InterromperProcessamentoUf` (status "Interrompido") à entidade `ExecucaoCrawler`
- UFs não alcançadas por interrupção permanecem como "Pendente"
- Frontend exibe `MunicipiosAtivos` e trata status "Interrompido" com severidade `warn`

## Testes

- **11 novos testes unitários** de regressão:
  - 5 testes de entidade (`ExecucaoCrawler`): FinalizarProcessamentoUf, FalharProcessamentoUf, InterromperProcessamentoUf, status inicial, IniciarProcessamentoUf
  - 6 testes de serviço (`CrawlerService`): falha total, interrupção por CertificateProtection, zero ativos, convênio ativo, falhas parciais, UFs pendentes após interrupção
- **429/430 testes passam** (1 falha pré-existente não relacionada)
- **37/37 testes de integração passam**

## Arquivos alterados

| Arquivo | Tipo |
|---------|------|
| `ExecucaoCrawler.cs` | Entidade — `MunicipiosAtivos`, novos métodos |
| `CrawlerService.cs` | Serviço — loop unificado em `FaseConvenioAsync` |
| `CrawlerServiceTests.cs` | +6 testes de regressão |
| `ExecucaoCrawlerTests.cs` | +5 testes de entidade |
| `crawler.models.ts` | +`municipiosAtivos` na interface |
| `crawler-status.component.html` | Exibir "Ativos" nos cards |
| `crawler-status.component.ts` | Severidade para "Interrompido" |

## OpenSpec

Artefatos completos em `openspec/changes/fix-progresso-uf-prematuro/` (proposal, design, specs, tasks — todos concluídos).