### PR TITLE
docs: atualizacao final da documentacao pos-implementacao

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ![.NET 10](https://img.shields.io/badge/.NET-10-512BD4?logo=dotnet&logoColor=white)
 ![Angular 21](https://img.shields.io/badge/Angular-21-DD0031?logo=angular&logoColor=white)
-![MongoDB](https://img.shields.io/badge/MongoDB-8.0-47A248?logo=mongodb&logoColor=white)
+![MongoDB](https://img.shields.io/badge/MongoDB-7-47A248?logo=mongodb&logoColor=white)
 ![Docker](https://img.shields.io/badge/Docker-Compose-2496ED?logo=docker&logoColor=white)
 
 [![SonarQube Cloud](https://sonarcloud.io/images/project_badges/sonarcloud-light.svg)](https://sonarcloud.io/summary/new_code?id=john182_poc-open-spec)
@@ -108,6 +108,7 @@ docker compose up --build
 | [Design Tokens](docs/design-tokens.md) | Tokens CSS, variaveis de tema, personalizacao PrimeNG |
 | [Estrategia de PRs](docs/pr-strategy.md) | Fluxo de branches, convencao de commits, processo de review |
 | [API Externa NFS-e](docs/external-api-analysis.md) | Analise da API adn.nfse.gov.br, endpoints, autenticacao mTLS |
+| [Benchmark do Crawler](docs/crawler-benchmark-otimizacao.md) | Resultados de benchmark e otimizacoes de performance do crawler |
 
 ---
 
@@ -126,7 +127,7 @@ docker compose up --build
 cd backend/MapaTributario
 dotnet restore
 dotnet run --project src/MapaTributario.API
-# API disponivel em https://localhost:5001
+# API disponivel em http://localhost:5000
 ```
 
 ### Frontend
@@ -141,8 +142,10 @@ ng serve
 ### MongoDB (standalone)
 
 ```bash
-docker run -d -p 27017:27017 --name mongo mongo:8
+docker run -d -p 27018:27017 --name mongo mongo:7
 ```
+
+> **Nota:** A porta padrão do host para o MongoDB neste projeto e `27018` (mapeada para `27017` dentro do container), conforme definido no `docker-compose.yml`.
 
 ---
 
@@ -174,7 +177,7 @@ npx cypress run
 | POST | /api/v1/auth/login | Login (retorna JWT) |
 | POST | /api/v1/auth/refresh | Refresh do access token |
 
-### Consulta (publicos)
+### Consulta (requerem JWT)
 
 | Metodo | Endpoint | Descricao |
 |--------|----------|-----------|
@@ -210,7 +213,7 @@ npx cypress run
 ### Round 1 — Concluido
 
 - [x] **Infra Docker** — Docker Compose, Dockerfiles, Nginx, .env
-- [x] **Backend Auth** — JWT auth (register/login/refresh), DDD, FluentResults, FluentValidation, 97% coverage
+- [x] **Backend Auth** — JWT auth (register/login/refresh), DDD, FluentResults, FluentValidation
 - [x] **Frontend Foundation** — Layout PrimeNG, design tokens, componentes base, rotas, Vitest + Cypress base
 
 ### Round 2 — Concluido
@@ -221,8 +224,6 @@ npx cypress run
 - [x] **Frontend Role Control** — RoleService, AdminGuard, menu condicional por role
 - [x] **Frontend Consulta** — Mapa do Brasil, selecao estado/municipio, listagem aliquotas com filtros
 - [x] **Frontend Crawler Admin** — Status, execucao manual, certificado, historico de execucoes
-- [x] **E2E Cypress** — Testes de auth, layout, navegacao, consulta e crawler admin
-- [x] **Docs** — Contratos, especificacoes, estrategias documentadas
 
 ### Round 3 — Concluido
 
@@ -231,7 +232,22 @@ npx cypress run
 - [x] **Tela Angular Admin** — Configuracao do crawler, tooltips, labels sem detalhes de implementacao
 - [x] **Tracking por UF** — Progresso por UF com polling 5s na tela de status
 - [x] **Capitais Primeiro** — Botao que processa capitais estaduais primeiro, depois demais municipios
-- [x] **Testes** — 230 unit backend, 210 unit frontend, 7 specs E2E Cypress
+
+### Integracao e Qualidade — Concluido
+
+- [x] **Integracao Ponta a Ponta (Issue #9)** — Fluxo completo admin: upload certificado, configurar crawler, executar, consultar aliquotas coletadas
+- [x] **E2E Cypress (Issue #10)** — 48 testes E2E cobrindo auth, layout, consulta, crawler admin e erros
+- [x] **Persistencia de Certificado PFX** — Certificado armazenado em MongoDB (colecao `certificados_digitais`) com cache em memoria
+- [x] **Documentacao Final (Issue #11)** — Atualizacao de README, contratos, diagramas e estrategia de testes
+
+### Metricas de Teste
+
+| Camada | Testes | Framework |
+|--------|--------|-----------|
+| Backend unitario | 457 | xUnit + Moq + Shouldly |
+| Backend integracao | 38 | xUnit + Testcontainers + MongoDB |
+| Frontend unitario | 281 | Vitest + Angular Testing Library |
+| E2E | 48 (5 specs) | Cypress 14.4.1 |
 
 ---
 
@@ -244,4 +260,4 @@ GET /parametrizacao/{municipio}/{servico}/{competencia}/aliquota
 GET /parametrizacao/{municipio}/convenio
 ```
 
-Consulte `openspec/changes/full-stack-aliquotas-municipais/docs/external-api-analysis.md` para detalhes completos.
+Consulte `docs/external-api-analysis.md` para detalhes completos.

--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -825,6 +825,8 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiIs...
 
 Endpoints para gerenciamento do certificado digital PFX usado pelo worker para autenticacao mTLS com a API NFS-e.
 
+> **Persistencia:** O certificado e armazenado no MongoDB (colecao `certificados_digitais`) e carregado em cache de memoria na inicializacao da aplicacao. Isso garante que o certificado sobrevive a reinicializacoes do container sem necessidade de re-upload.
+
 ---
 
 ### POST /api/v1/crawler/certificado

--- a/docs/frontend-foundation.md
+++ b/docs/frontend-foundation.md
@@ -802,7 +802,7 @@ export interface ProgressoUf {
 
 ### Cobertura Atual
 
-- **210 testes unitarios** passando (Vitest + Testing Library)
+- **281 testes unitarios** passando (Vitest + Testing Library)
 - Build de producao sem erros
 
 ### Testes do Crawler

--- a/docs/technical-doc.md
+++ b/docs/technical-doc.md
@@ -50,8 +50,8 @@ graph TB
             WK["Worker BackgroundService<br/>CrawlerService, NfseApiClient"]
         end
 
-        subgraph "Container: MongoDB 7 - porta 27017"
-            DB["MongoDB<br/>8 colecoes"]
+        subgraph "Container: MongoDB 7 - porta 27018 (host) / 27017 (interno)"
+            DB["MongoDB<br/>9 colecoes"]
         end
 
         subgraph "Container: Cypress - apenas dev/CI"
@@ -93,7 +93,7 @@ graph TB
 | **Documentacao API** | OpenAPI | 3.0 | Endpoint JSON bruto em `/openapi/v1.json` (apenas em Development); sem Swagger UI; gerado automaticamente pelo ASP.NET Core `AddOpenApi()` |
 | **Testes Backend** | xUnit | latest | Padrao .NET; suporte a injecao de dependencia e paralelismo |
 | **Testes Frontend** | Vitest | 4.x | Rapido; ja configurado no projeto Angular |
-| **E2E Tests** | Cypress | 13.x | DX excelente para testes de UI; seletores estaveis; bom suporte a SPA |
+| **E2E Tests** | Cypress | 14.4.1 | DX excelente para testes de UI; seletores estaveis; bom suporte a SPA |
 | **Servidor Web** | Nginx | alpine | Embutido no container frontend (multi-stage build); serve SPA Angular; proxy reverso para backend |
 | **Containerizacao** | Docker | - | Ambiente reprodutivel; multi-stage builds para imagens otimizadas |
 | **Orquestracao** | Docker Compose | v2 | Orquestracao local simples; define servicos, redes, volumes |
@@ -134,6 +134,7 @@ erDiagram
     FILA_PROCESSAMENTO }|--|| MUNICIPIOS : "referencia"
     FILA_PROCESSAMENTO }|--|| SERVICOS : "referencia"
     CONFIGURACOES_CRAWLER ||--|| CONFIGURACOES_CRAWLER : "singleton ativo"
+    CERTIFICADOS_DIGITAIS ||--|| CERTIFICADOS_DIGITAIS : "singleton unico"
 
     ESTADOS {
         ObjectId _id PK
@@ -220,6 +221,16 @@ erDiagram
         int paralelismo
         datetime criadoEm
         datetime atualizadoEm
+    }
+
+    CERTIFICADOS_DIGITAIS {
+        string _id PK
+        bytes pfxBytes
+        string senha
+        string thumbprint
+        string subject
+        datetime validoAte
+        datetime criadoEm
     }
 ```
 
@@ -396,6 +407,24 @@ Configuracoes de comportamento do crawler (timeouts, retry, paralelismo, CRON, e
 
 ---
 
+#### `certificados_digitais`
+
+Armazena o certificado digital PFX para autenticacao mTLS com a API NFS-e. Singleton com ID fixo — apenas um certificado ativo por vez. Persistido em MongoDB e carregado em cache de memoria na inicializacao da aplicacao.
+
+| Campo | Tipo | Descricao | Exemplo |
+|-------|------|-----------|---------|
+| `_id` | string | Identificador fixo (sempre `"certificado_digital_unico"`) | `"certificado_digital_unico"` |
+| `pfxBytes` | bytes | Conteudo binario do arquivo PFX | (binario) |
+| `senha` | string | Senha do certificado PFX (texto plano) | `"MinhaSenha"` |
+| `thumbprint` | string | Thumbprint (hash) do certificado | `"AB12CD34..."` |
+| `subject` | string | Subject (CN) do certificado | `"EMPRESA LTDA:12345678000190"` |
+| `validoAte` | datetime | Data de expiracao do certificado | `2027-01-15T00:00:00Z` |
+| `criadoEm` | datetime | Timestamp de upload do certificado | `2026-04-01T10:30:00Z` |
+
+> **Nota:** O certificado PFX e armazenado sem criptografia adicional no MongoDB. Esta e uma decisao consciente para o POC. Em producao, considerar criptografia at-rest ou um vault dedicado (Azure Key Vault, HashiCorp Vault).
+
+---
+
 ## 4. Fluxo de Autenticacao JWT
 
 ### 4.1 Registro e Login
@@ -466,7 +495,7 @@ sequenceDiagram
         B-->>F: 200 OK { dados }
     end
 
-    Note over F,B: Nota: Endpoints de consulta (/api/v1/estados, municipios, aliquotas) sao publicos e nao requerem JWT.
+    Note over F,B: Nota: Endpoints de consulta (/api/v1/estados, municipios, aliquotas) requerem JWT (qualquer usuario autenticado) mas nao exigem role Admin.
 
     rect rgb(255, 230, 230)
         Note over F,B: Token Expirado - Refresh Automatico
@@ -731,7 +760,7 @@ graph TB
 
             BE["backend<br/>build: ./backend/MapaTributario<br/>image: .NET 10 runtime<br/>ports: 5000:5000<br/>depends_on: mongodb<br/>env: JWT_SECRET, MONGO_URI"]
 
-            MG["mongodb<br/>image: mongo:7<br/>ports: 27017:27017<br/>volumes: mongo-data:/data/db"]
+            MG["mongodb<br/>image: mongo:7<br/>ports: 27018:27017<br/>volumes: mongo-data:/data/db"]
         end
     end
 
@@ -978,15 +1007,17 @@ backend/MapaTributario/
 │       │   ├── Resilience/
 │       │   │   ├── RateLimiter.cs
 │       │   │   └── CircuitBreaker.cs
-│       │   └── Crawler/
-│       │       ├── CertificadoStore.cs    # Armazenamento de certificado PFX em memoria
-│       │       └── ExecutionGuard.cs      # Controle de execucao concorrente do crawler
+│       │   ├── Crawler/
+│       │   │   ├── CertificadoStore.cs    # Armazenamento de certificado PFX: persistido em MongoDB + cache em memoria
+│       │   │   └── ExecutionGuard.cs      # Controle de execucao concorrente do crawler
+│       │   └── Repository/
+│       │       ├── CertificadoDigitalRepository.cs # Repositorio MongoDB para colecao certificados_digitais
 │       │
 │       ├── Controllers/
 │       │   ├── AuthController.cs
-│       │   ├── ConsultaController.cs      # Endpoints publicos (sem [Authorize])
-│       │   ├── CrawlerController.cs       # Requer JWT ([Authorize])
-│       │   ├── CertificadoController.cs   # Requer JWT ([Authorize])
+│       │   ├── ConsultaController.cs      # Requer JWT ([Authorize], qualquer usuario autenticado)
+│       │   ├── CrawlerController.cs       # Requer JWT + Role Admin ([Authorize(Roles = "Admin")])
+│       │   ├── CertificadoController.cs   # Requer JWT + Role Admin ([Authorize(Roles = "Admin")])
 │       │   └── HealthController.cs
 │       ├── Middleware/
 │       │   └── ErrorHandlingMiddleware.cs
@@ -1017,8 +1048,8 @@ backend/MapaTributario/
 
 - **Projeto unico com separacao por pastas:** As camadas Domain, Application, Infrastructure e API/Host coexistem em um unico projeto (`MapaTributario.API`). A separacao e logica, via pastas e namespaces. Isso simplifica build e deploy sem sacrificar organizacao.
 - **DI por camada:** O `Program.cs` chama `AddMapaTributarioInfrastructure()` (MongoDB, repositorios, auth infra, certificado, seed, API client) e `AddMapaTributarioApplication()` (services, use cases, resiliencia, JWT auth, FluentValidation, background service). Cada extension registra apenas os componentes de sua camada.
-- **Indices centralizados:** A classe `MongoIndexSetup` cria todos os indices de todas as 8 colecoes em um unico ponto, chamado na inicializacao via `app.ApplyMongoIndexesAsync()`. Repositorios nao criam indices em seus construtores.
-- **Endpoints de consulta publicos:** Os endpoints `/api/v1/estados`, `/api/v1/estados/:uf/municipios`, `/api/v1/municipios/:codigoIbge/aliquotas` e `/api/v1/municipios/:codigoIbge/aliquotas/:codigoServico` nao possuem `[Authorize]`. Os endpoints do crawler e certificado exigem JWT (`[Authorize]`), mas sem validacao de role Admin no backend; a restricao por perfil e aplicada pelo frontend.
+- **Indices centralizados:** A classe `MongoIndexSetup` cria todos os indices de todas as 9 colecoes em um unico ponto, chamado na inicializacao via `app.ApplyMongoIndexesAsync()`. Repositorios nao criam indices em seus construtores.
+- **Endpoints de consulta autenticados:** Os endpoints `/api/v1/estados`, `/api/v1/estados/:uf/municipios`, `/api/v1/municipios/:codigoIbge/aliquotas` e `/api/v1/municipios/:codigoIbge/aliquotas/:codigoServico` possuem `[Authorize]` (qualquer usuario autenticado). Os endpoints do crawler e certificado exigem `[Authorize(Roles = "Admin")]`.
 
 ### 8.2 Frontend Angular - Feature Modules
 
@@ -1289,3 +1320,4 @@ Os contratos de API estao documentados manualmente em [`docs/api-contracts.md`](
 | Data | Versao | Descricao |
 |------|--------|-----------|
 | 2026-03-31 | 1.0 | Versao inicial do documento tecnico |
+| 2026-04-04 | 1.1 | Atualizacao pos-implementacao: correcao de portas MongoDB (27018), versao Cypress (14.4.1), adicao colecao certificados_digitais, correcao de autorizacao dos endpoints de consulta ([Authorize]), atualizacao do numero de colecoes (9) |

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -27,8 +27,8 @@ A estrategia segue a piramide classica de testes, priorizando testes unitarios n
 ### Framework e Ferramentas
 
 - **Framework:** xUnit
-- **Mocking:** NSubstitute
-- **Assertions:** FluentAssertions
+- **Mocking:** Moq
+- **Assertions:** Shouldly
 - **Dados de teste:** Bogus (quando necessario gerar massa)
 
 ### O que testar
@@ -204,96 +204,60 @@ frontend/
 ### Estrutura do Projeto
 
 ```
-e2e/
-  cypress/
-    e2e/
-      auth.cy.ts
-      navigation.cy.ts
-      map.cy.ts
-      consultation.cy.ts
-      errors.cy.ts
-    fixtures/
-      users.json
-      estados.json
-      municipios.json
-      servicos.json
-    support/
-      commands.ts
-      e2e.ts
-    plugins/
-      index.ts
-  cypress.config.ts
-  tsconfig.json
+cypress/
+  e2e/
+    auth.cy.ts
+    navigation.cy.ts
+    map.cy.ts
+    consultation.cy.ts
+    errors.cy.ts
+  support/
+    commands.ts
+    e2e.ts
+cypress.config.ts
 ```
 
 ### Ambiente de Teste
 
-O ambiente E2E roda inteiramente via Docker Compose com perfil de teste.
+Os testes E2E rodam contra o ambiente Docker Compose do projeto (`docker compose up`). Os containers do backend, frontend e MongoDB precisam estar rodando.
 
-```yaml
-# docker-compose.e2e.yml
-services:
-  api:
-    build: ./backend
-    environment:
-      - ASPNETCORE_ENVIRONMENT=Test
-      - MongoDB__ConnectionString=mongodb://mongodb-e2e:27017
-      - MongoDB__DatabaseName=mapatributario_e2e
-    depends_on:
-      - mongodb-e2e
+```bash
+# Subir ambiente
+docker compose up -d
 
-  mongodb-e2e:
-    image: mongo:7
-    ports:
-      - "27019:27017"
+# Rodar testes E2E (da raiz do projeto)
+npx cypress run
 
-  frontend:
-    build: ./frontend
-    ports:
-      - "4200:80"
-    depends_on:
-      - api
-
-  seed:
-    build: ./backend
-    command: ["dotnet", "run", "--project", "Seed", "--", "--environment", "e2e"]
-    depends_on:
-      - mongodb-e2e
+# Ou em modo interativo
+npx cypress open
 ```
+
+O Cypress se conecta ao frontend via `http://localhost:4200` (configuravel no `cypress.config.ts`). O seed automatico do backend garante dados iniciais (estados, municipios, servicos, usuario admin `admin@admin.com` / `12345678`).
 
 ### Estrategia de Seed
 
-A massa de dados para E2E deve ser:
+A massa de dados para E2E vem do seed automatico do backend (que roda na inicializacao):
 
-1. **Deterministica:** Mesmos dados toda vez, sem aleatoriedade
-2. **Minima:** Apenas o necessario para cobrir os cenarios
-3. **Isolada:** Cada execucao comeca com dados limpos
+1. **Deterministica:** Seed via `AdminSeedService`, `EstadosSeed`, `MunicipiosSeed`, `ServicosSeed`, `ConfiguracaoCrawlerSeed`
+2. **Completa:** Todos os 27 estados, ~5.570 municipios, 203 servicos, usuario admin com role Admin
+3. **Automatica:** Executada na inicializacao do backend, sem necessidade de setup manual
 
-**Dados de seed:**
-- 2 usuarios (um valido, um para teste de permissao)
-- 3 estados com dados completos (SP, RJ, MG)
-- 5 municipios por estado de teste
-- 10 servicos com aliquotas variadas por municipio de teste
-- 1 municipio sem servicos (para testar estado vazio)
+**Dados de seed disponiveis:**
+- 1 usuario admin (email: `admin@admin.com`, senha: `12345678`, role: Admin)
+- 27 estados brasileiros
+- ~5.570 municipios (todos os municipios IBGE)
+- 203 codigos de servico (LC 116/2003)
+- 1 configuracao padrao do crawler
 
 ### Custom Commands
 
 ```typescript
 // support/commands.ts
 
-// Autenticacao
+// Autenticacao via UI (login atraves do formulario)
 Cypress.Commands.add('login', (email?: string, password?: string) => { /* ... */ });
-Cypress.Commands.add('logout', () => { /* ... */ });
-Cypress.Commands.add('register', (user: RegisterPayload) => { /* ... */ });
 
-// Navegacao
-Cypress.Commands.add('navigateTo', (route: string) => { /* ... */ });
-
-// API
-Cypress.Commands.add('seedDatabase', () => { /* ... */ });
-Cypress.Commands.add('resetDatabase', () => { /* ... */ });
-
-// Seletores
+// Seletores por atributo data-cy
 Cypress.Commands.add('getByCy', (selector: string) => {
   return cy.get(`[data-cy="${selector}"]`);
 });
@@ -382,69 +346,39 @@ Usar atributo `data-cy` para todos os elementos que serao acessados nos testes E
 
 ## Massa de Dados
 
-### Fixtures
+Os testes E2E utilizam os dados de seed do backend (carregados automaticamente na inicializacao). O login padrao para testes e:
 
 ```json
-// fixtures/users.json
 {
-  "validUser": {
-    "name": "Usuario Teste",
-    "email": "teste@mapatributario.com",
-    "password": "Teste@123"
-  },
-  "invalidUser": {
-    "email": "invalido@teste.com",
-    "password": "senhaerrada"
-  }
+  "email": "admin@admin.com",
+  "password": "12345678"
 }
 ```
 
-```json
-// fixtures/estados.json
-{
-  "estados": [
-    { "uf": "SP", "nome": "Sao Paulo", "totalMunicipios": 5 },
-    { "uf": "RJ", "nome": "Rio de Janeiro", "totalMunicipios": 5 },
-    { "uf": "MG", "nome": "Minas Gerais", "totalMunicipios": 5 }
-  ]
-}
-```
-
-```json
-// fixtures/municipios.json
-{
-  "SP": [
-    { "codigo": "3550308", "nome": "Sao Paulo", "totalServicos": 10 },
-    { "codigo": "3509502", "nome": "Campinas", "totalServicos": 8 },
-    { "codigo": "3547809", "nome": "Santos", "totalServicos": 0 }
-  ]
-}
-```
+Os testes que precisam de um usuario novo utilizam o fluxo de registro via UI.
 
 ### Estrategia de Reset
 
-Antes de cada suite:
-1. Chamar endpoint de reset do banco de teste: `POST /api/test/reset`
-2. Executar seed: `POST /api/test/seed`
-3. Verificar que seed foi aplicado: `GET /api/test/health`
-
-Esses endpoints so existem quando `ASPNETCORE_ENVIRONMENT=Test`.
+Os testes sao projetados para funcionar com o seed existente, sem necessidade de reset entre execucoes. O custom command `cy.login()` realiza login via UI e armazena o token para uso nas requisicoes subsequentes.
 
 ---
 
 ## Ambiente de Teste
 
-### Docker Compose - Perfil de Teste
+### Como Executar
 
 ```bash
-# Subir ambiente de testes
-docker compose -f docker-compose.yml -f docker-compose.e2e.yml up -d
+# 1. Subir ambiente completo
+docker compose up -d
 
-# Rodar testes E2E
-cd e2e && npx cypress run
+# 2. Rodar testes unitarios backend
+cd backend/MapaTributario && dotnet test --no-restore --verbosity minimal
 
-# Derrubar ambiente
-docker compose -f docker-compose.yml -f docker-compose.e2e.yml down -v
+# 3. Rodar testes unitarios frontend
+cd frontend/MapaTributario-ui && npx ng test --watch=false
+
+# 4. Rodar testes E2E (da raiz do projeto, com containers rodando)
+npx cypress run
 ```
 
 ### CI Pipeline
@@ -459,6 +393,17 @@ docker compose -f docker-compose.yml -f docker-compose.e2e.yml down -v
 7. Coletar relatorios de cobertura
 8. Derrubar ambiente
 ```
+
+---
+
+## Metricas Atuais (pos-implementacao)
+
+| Camada | Testes | Framework | Status |
+|--------|--------|-----------|--------|
+| Backend unitario | 457 | xUnit + Moq + Shouldly | Passando |
+| Backend integracao | 38 | xUnit + Testcontainers + MongoDB | Passando |
+| Frontend unitario | 281 | Vitest + Angular Testing Library | Passando |
+| E2E | 48 (5 specs) | Cypress 14.4.1 | Passando |
 
 ---
 

--- a/docs/worker-strategy.md
+++ b/docs/worker-strategy.md
@@ -626,7 +626,7 @@ Os parametros abaixo permanecem em `appsettings.json` por serem relacionados a i
 | CircuitBreaker.MinimumSamples | 10 | Minimo de amostras para avaliar o circuito |
 | MunicipalityRediscoveryDays | 30 | Dias para reverificar municipios inativos |
 | EnableHistoricalCollection | false | Habilitar coleta historica de aliquotas |
-| Certificate (via API) | - | O certificado PFX e gerenciado via endpoints REST: `POST /api/v1/crawler/certificado` (upload), `GET /api/v1/crawler/certificado` (status), `DELETE /api/v1/crawler/certificado` (remover). Nao requer variavel de ambiente. |
+| Certificate (via API) | - | O certificado PFX e gerenciado via endpoints REST: `POST /api/v1/crawler/certificado` (upload), `GET /api/v1/crawler/certificado` (status), `DELETE /api/v1/crawler/certificado` (remover). Nao requer variavel de ambiente. O certificado e **persistido no MongoDB** (colecao `certificados_digitais`) e carregado em cache de memoria na inicializacao da aplicacao, sobrevivendo a reinicializacoes do container. |
 
 ### Variaveis de ambiente
 


### PR DESCRIPTION
## Summary

Atualizacao completa da documentacao para refletir o estado final da implementacao, fechando a Issue #11.

### Alteracoes por arquivo

**README.md:**
- Corrigido badge MongoDB 8.0 → 7 (versao real no docker-compose)
- Corrigida URL do backend local: `https://localhost:5001` → `http://localhost:5000`
- Corrigida porta MongoDB standalone: 27017 → 27018 (consistente com docker-compose)
- Atualizada secao Status do Projeto com rounds de integracao e metricas finais
- Corrigidos endpoints de consulta: eram listados como "publicos" mas requerem JWT
- Adicionado link para `docs/crawler-benchmark-otimizacao.md`
- Corrigida referencia do doc da API externa

**docs/technical-doc.md:**
- Corrigida versao do Cypress: 13.x → 14.4.1
- Corrigida porta host do MongoDB no diagrama Docker: 27017 → 27018
- Adicionada colecao `certificados_digitais` ao diagrama ER e detalhamento
- Atualizado numero de colecoes: 8 → 9
- Corrigida autorizacao dos endpoints: consulta com `[Authorize]`, crawler/certificado com `[Authorize(Roles = "Admin")]`
- Atualizado historico do documento

**docs/test-strategy.md:**
- Corrigido mocking: NSubstitute → Moq
- Corrigidas assertions: FluentAssertions → Shouldly
- Atualizada estrutura de diretorios do Cypress para refletir implementacao real
- Corrigido ambiente de teste e seed para refletir fluxo atual (seed automatico do backend)
- Adicionada secao de metricas atuais (457+38 backend, 281 frontend, 48 E2E)

**docs/api-contracts.md:**
- Adicionada nota sobre persistencia do certificado PFX em MongoDB (colecao `certificados_digitais`)

**docs/frontend-foundation.md:**
- Atualizada contagem de testes: 210 → 281

**docs/worker-strategy.md:**
- Adicionada nota sobre persistencia do certificado PFX em MongoDB com cache em memoria

### Criterios de aceite
- [x] README claro para novo dev (clone → docker compose up → usar)
- [x] api-contracts.md reflete endpoints reais (verificado contra controllers)
- [x] Diagramas mostram arquitetura real (portas, colecoes, autorizacao)
- [x] Sem divergencias significativas entre docs e codigo

Closes #11