### PR TITLE
feat: implementar perfil de usuario com edicao de nome e senha

### DIFF
--- a/backend/MapaTributario/src/MapaTributario.API/Application/Perfil/Contracts/AtualizarPerfilRequest.cs
+++ b/backend/MapaTributario/src/MapaTributario.API/Application/Perfil/Contracts/AtualizarPerfilRequest.cs
@@ -1,0 +1,8 @@
+namespace MapaTributario.API.Application.Perfil.Contracts;
+
+public class AtualizarPerfilRequest
+{
+    public string Nome { get; set; } = null!;
+    public string? SenhaAtual { get; set; }
+    public string? NovaSenha { get; set; }
+}

--- a/backend/MapaTributario/src/MapaTributario.API/Application/Perfil/Contracts/AtualizarPerfilResponse.cs
+++ b/backend/MapaTributario/src/MapaTributario.API/Application/Perfil/Contracts/AtualizarPerfilResponse.cs
@@ -1,0 +1,9 @@
+namespace MapaTributario.API.Application.Perfil.Contracts;
+
+public class AtualizarPerfilResponse
+{
+    public string Id { get; set; } = null!;
+    public string Nome { get; set; } = null!;
+    public string Email { get; set; } = null!;
+    public string AccessToken { get; set; } = null!;
+}

--- a/backend/MapaTributario/src/MapaTributario.API/Application/Perfil/Contracts/PerfilResponse.cs
+++ b/backend/MapaTributario/src/MapaTributario.API/Application/Perfil/Contracts/PerfilResponse.cs
@@ -1,0 +1,8 @@
+namespace MapaTributario.API.Application.Perfil.Contracts;
+
+public class PerfilResponse
+{
+    public string Id { get; set; } = null!;
+    public string Nome { get; set; } = null!;
+    public string Email { get; set; } = null!;
+}

--- a/backend/MapaTributario/src/MapaTributario.API/Controllers/PerfilController.cs
+++ b/backend/MapaTributario/src/MapaTributario.API/Controllers/PerfilController.cs
@@ -1,0 +1,97 @@
+using System.Security.Claims;
+using FluentValidation;
+using MapaTributario.API.Application.Perfil.Contracts;
+using MapaTributario.API.Domain.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace MapaTributario.API.Controllers;
+
+[ApiController]
+[Route("api/v1/perfil")]
+[Authorize]
+public class PerfilController : ControllerBase
+{
+    private readonly IUserRepository _userRepository;
+    private readonly ITokenProvider _tokenProvider;
+    private readonly IPasswordHasher _passwordHasher;
+
+    public PerfilController(
+        IUserRepository userRepository,
+        ITokenProvider tokenProvider,
+        IPasswordHasher passwordHasher)
+    {
+        _userRepository = userRepository;
+        _tokenProvider = tokenProvider;
+        _passwordHasher = passwordHasher;
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> ObterPerfil()
+    {
+        var userId = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        if (userId is null)
+            return Unauthorized(new { erro = "Usuário não identificado" });
+
+        var usuario = await _userRepository.GetByIdAsync(userId);
+        if (usuario is null)
+            return NotFound(new { erro = "Usuário não encontrado" });
+
+        return Ok(new PerfilResponse
+        {
+            Id = usuario.Id,
+            Nome = usuario.Nome,
+            Email = usuario.Email
+        });
+    }
+
+    [HttpPut]
+    public async Task<IActionResult> AtualizarPerfil(
+        [FromBody] AtualizarPerfilRequest request,
+        [FromServices] IValidator<AtualizarPerfilRequest> validator)
+    {
+        var validationError = await ValidarRequestAsync(request, validator);
+        if (validationError is not null) return validationError;
+
+        var userId = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        if (userId is null)
+            return Unauthorized(new { erro = "Usuário não identificado" });
+
+        var usuario = await _userRepository.GetByIdAsync(userId);
+        if (usuario is null)
+            return NotFound(new { erro = "Usuário não encontrado" });
+
+        usuario.AtualizarNome(request.Nome);
+
+        if (!string.IsNullOrEmpty(request.NovaSenha))
+        {
+            if (!_passwordHasher.Verify(request.SenhaAtual!, usuario.PasswordHash))
+                return BadRequest(new { erro = "Senha atual incorreta" });
+
+            var novoHash = _passwordHasher.Hash(request.NovaSenha);
+            usuario.AtualizarSenha(novoHash);
+        }
+
+        await _userRepository.AtualizarAsync(usuario);
+
+        var novoToken = _tokenProvider.GenerateAccessToken(usuario);
+
+        return Ok(new AtualizarPerfilResponse
+        {
+            Id = usuario.Id,
+            Nome = usuario.Nome,
+            Email = usuario.Email,
+            AccessToken = novoToken
+        });
+    }
+
+    private static async Task<BadRequestObjectResult?> ValidarRequestAsync<T>(T request, IValidator<T> validator)
+    {
+        var validation = await validator.ValidateAsync(request);
+        if (!validation.IsValid)
+        {
+            return new BadRequestObjectResult(new { erro = "Validação falhou", detalhes = validation.Errors.Select(e => e.ErrorMessage).ToArray() });
+        }
+        return null;
+    }
+}

--- a/backend/MapaTributario/src/MapaTributario.API/Domain/Entities/User.cs
+++ b/backend/MapaTributario/src/MapaTributario.API/Domain/Entities/User.cs
@@ -28,4 +28,20 @@ public class User
     public void SetId(string id) => Id = id;
 
     public void Deactivate() => Ativo = false;
+
+    public void AtualizarNome(string nome)
+    {
+        if (string.IsNullOrWhiteSpace(nome))
+            throw new ArgumentException("Nome não pode ser vazio.", nameof(nome));
+
+        Nome = nome;
+    }
+
+    public void AtualizarSenha(string novoHash)
+    {
+        if (string.IsNullOrWhiteSpace(novoHash))
+            throw new ArgumentException("Hash da senha não pode ser vazio.", nameof(novoHash));
+
+        PasswordHash = novoHash;
+    }
 }

--- a/backend/MapaTributario/src/MapaTributario.API/Domain/Interfaces/IUserRepository.cs
+++ b/backend/MapaTributario/src/MapaTributario.API/Domain/Interfaces/IUserRepository.cs
@@ -7,4 +7,5 @@ public interface IUserRepository
     Task<User> CreateAsync(User user);
     Task<User?> GetByEmailAsync(string email);
     Task<User?> GetByIdAsync(string id);
+    Task AtualizarAsync(User user);
 }

--- a/backend/MapaTributario/src/MapaTributario.API/Validators/AtualizarPerfilRequestValidator.cs
+++ b/backend/MapaTributario/src/MapaTributario.API/Validators/AtualizarPerfilRequestValidator.cs
@@ -1,0 +1,22 @@
+using FluentValidation;
+using MapaTributario.API.Application.Perfil.Contracts;
+
+namespace MapaTributario.API.Validators;
+
+public class AtualizarPerfilRequestValidator : AbstractValidator<AtualizarPerfilRequest>
+{
+    public AtualizarPerfilRequestValidator()
+    {
+        RuleFor(x => x.Nome)
+            .NotEmpty().WithMessage("Nome é obrigatório")
+            .MinimumLength(2).WithMessage("Nome deve ter no mínimo 2 caracteres");
+
+        RuleFor(x => x.SenhaAtual)
+            .NotEmpty().WithMessage("Senha atual é obrigatória para alterar a senha")
+            .When(x => !string.IsNullOrEmpty(x.NovaSenha));
+
+        RuleFor(x => x.NovaSenha)
+            .MinimumLength(8).WithMessage("Nova senha deve ter no mínimo 8 caracteres")
+            .When(x => !string.IsNullOrEmpty(x.NovaSenha));
+    }
+}

--- a/backend/MapaTributario/src/MapaTributario.API/infrastructure/Repository/UserRepository.cs
+++ b/backend/MapaTributario/src/MapaTributario.API/infrastructure/Repository/UserRepository.cs
@@ -30,4 +30,14 @@ public class UserRepository : IUserRepository
     {
         return await _users.Find(u => u.Id == id).FirstOrDefaultAsync();
     }
+
+    public async Task AtualizarAsync(User user)
+    {
+        var filtro = Builders<User>.Filter.Eq(u => u.Id, user.Id);
+        var atualizacao = Builders<User>.Update
+            .Set(u => u.Nome, user.Nome)
+            .Set(u => u.PasswordHash, user.PasswordHash);
+
+        await _users.UpdateOneAsync(filtro, atualizacao);
+    }
 }

--- a/backend/MapaTributario/tests/MapaTributario.Tests.Integration/PerfilControllerTests.cs
+++ b/backend/MapaTributario/tests/MapaTributario.Tests.Integration/PerfilControllerTests.cs
@@ -1,0 +1,132 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using MapaTributario.API.Application.Auth.Contracts;
+using MapaTributario.API.Application.Perfil.Contracts;
+using Shouldly;
+
+namespace MapaTributario.Tests.Integration;
+
+public class PerfilControllerTests : IntegrationTestBase
+{
+    private async Task<string> RegistrarEObterTokenAsync(string email = "perfil@test.com", string nome = "Usuario Teste", string senha = "password123")
+    {
+        var registerReq = new RegisterRequest { Email = email, Nome = nome, Senha = senha };
+        var registerResp = await Client.PostAsJsonAsync("/api/v1/auth/register", registerReq);
+        var tokens = await registerResp.Content.ReadFromJsonAsync<AuthResponse>();
+        return tokens!.AccessToken;
+    }
+
+    private void ConfigurarAutorizacao(string token)
+    {
+        Client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+    }
+
+    [Fact]
+    public async Task ObterPerfil_ComTokenValido_Retorna200()
+    {
+        var token = await RegistrarEObterTokenAsync();
+        ConfigurarAutorizacao(token);
+
+        var response = await Client.GetAsync("/api/v1/perfil");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<PerfilResponse>();
+        body.ShouldNotBeNull();
+        body.Nome.ShouldBe("Usuario Teste");
+        body.Email.ShouldBe("perfil@test.com");
+        body.Id.ShouldNotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task ObterPerfil_SemToken_Retorna401()
+    {
+        var response = await Client.GetAsync("/api/v1/perfil");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task AtualizarPerfil_SomenteNome_Retorna200ComNovoToken()
+    {
+        var token = await RegistrarEObterTokenAsync("atualnome@test.com");
+        ConfigurarAutorizacao(token);
+
+        var request = new AtualizarPerfilRequest { Nome = "Nome Atualizado" };
+        var response = await Client.PutAsJsonAsync("/api/v1/perfil", request);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<AtualizarPerfilResponse>();
+        body.ShouldNotBeNull();
+        body.Nome.ShouldBe("Nome Atualizado");
+        body.AccessToken.ShouldNotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task AtualizarPerfil_NomeESenha_Retorna200()
+    {
+        var token = await RegistrarEObterTokenAsync("atualsenha@test.com", senha: "senhaoriginal123");
+        ConfigurarAutorizacao(token);
+
+        var request = new AtualizarPerfilRequest
+        {
+            Nome = "Nome Novo",
+            SenhaAtual = "senhaoriginal123",
+            NovaSenha = "novasenha456"
+        };
+        var response = await Client.PutAsJsonAsync("/api/v1/perfil", request);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<AtualizarPerfilResponse>();
+        body.ShouldNotBeNull();
+        body.Nome.ShouldBe("Nome Novo");
+    }
+
+    [Fact]
+    public async Task AtualizarPerfil_SenhaAtualIncorreta_Retorna400()
+    {
+        var token = await RegistrarEObterTokenAsync("senhaerrada@test.com");
+        ConfigurarAutorizacao(token);
+
+        var request = new AtualizarPerfilRequest
+        {
+            Nome = "Qualquer Nome",
+            SenhaAtual = "senha_incorreta",
+            NovaSenha = "novasenha456"
+        };
+        var response = await Client.PutAsJsonAsync("/api/v1/perfil", request);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task AtualizarPerfil_NomeVazio_Retorna400()
+    {
+        var token = await RegistrarEObterTokenAsync("nomevazio@test.com");
+        ConfigurarAutorizacao(token);
+
+        var request = new AtualizarPerfilRequest { Nome = "" };
+        var response = await Client.PutAsJsonAsync("/api/v1/perfil", request);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task AtualizarPerfil_VerificaPerfilAposAtualizacao_NomeReflete()
+    {
+        var token = await RegistrarEObterTokenAsync("verificar@test.com");
+        ConfigurarAutorizacao(token);
+
+        var updateRequest = new AtualizarPerfilRequest { Nome = "Nome Verificado" };
+        var updateResponse = await Client.PutAsJsonAsync("/api/v1/perfil", updateRequest);
+        var updateBody = await updateResponse.Content.ReadFromJsonAsync<AtualizarPerfilResponse>();
+
+        // Usar novo token para verificar
+        ConfigurarAutorizacao(updateBody!.AccessToken);
+        var getResponse = await Client.GetAsync("/api/v1/perfil");
+        var perfil = await getResponse.Content.ReadFromJsonAsync<PerfilResponse>();
+
+        perfil.ShouldNotBeNull();
+        perfil.Nome.ShouldBe("Nome Verificado");
+    }
+}

--- a/backend/MapaTributario/tests/MapaTributario.Tests.Unit/AtualizarPerfilRequestValidatorTests.cs
+++ b/backend/MapaTributario/tests/MapaTributario.Tests.Unit/AtualizarPerfilRequestValidatorTests.cs
@@ -1,0 +1,125 @@
+using MapaTributario.API.Application.Perfil.Contracts;
+using MapaTributario.API.Validators;
+using Shouldly;
+
+namespace MapaTributario.Tests.Unit;
+
+public class AtualizarPerfilRequestValidatorTests
+{
+    private readonly AtualizarPerfilRequestValidator _sut = new();
+
+    [Fact]
+    public async Task Given_NomeValidoSemSenhas_Should_PassarValidacao()
+    {
+        // Arrange
+        var request = new AtualizarPerfilRequest { Nome = "João Silva" };
+
+        // Act
+        var resultado = await _sut.ValidateAsync(request);
+
+        // Assert
+        resultado.IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Given_NomeVazio_Should_FalharValidacao()
+    {
+        // Arrange
+        var request = new AtualizarPerfilRequest { Nome = "" };
+
+        // Act
+        var resultado = await _sut.ValidateAsync(request);
+
+        // Assert
+        resultado.IsValid.ShouldBeFalse();
+        resultado.Errors.ShouldContain(e => e.PropertyName == "Nome");
+    }
+
+    [Fact]
+    public async Task Given_NomeCurtoComUmCaractere_Should_FalharValidacao()
+    {
+        // Arrange
+        var request = new AtualizarPerfilRequest { Nome = "A" };
+
+        // Act
+        var resultado = await _sut.ValidateAsync(request);
+
+        // Assert
+        resultado.IsValid.ShouldBeFalse();
+        resultado.Errors.ShouldContain(e => e.PropertyName == "Nome" && e.ErrorMessage.Contains("mínimo 2 caracteres"));
+    }
+
+    [Fact]
+    public async Task Given_NovaSenhaPreenchidaSemSenhaAtual_Should_FalharValidacao()
+    {
+        // Arrange
+        var request = new AtualizarPerfilRequest
+        {
+            Nome = "João Silva",
+            NovaSenha = "novaSenha123",
+            SenhaAtual = null
+        };
+
+        // Act
+        var resultado = await _sut.ValidateAsync(request);
+
+        // Assert
+        resultado.IsValid.ShouldBeFalse();
+        resultado.Errors.ShouldContain(e => e.PropertyName == "SenhaAtual");
+    }
+
+    [Fact]
+    public async Task Given_NovaSenhaCurtaMenosDeOitoCaracteres_Should_FalharValidacao()
+    {
+        // Arrange
+        var request = new AtualizarPerfilRequest
+        {
+            Nome = "João Silva",
+            SenhaAtual = "senhaAtual123",
+            NovaSenha = "curta"
+        };
+
+        // Act
+        var resultado = await _sut.ValidateAsync(request);
+
+        // Assert
+        resultado.IsValid.ShouldBeFalse();
+        resultado.Errors.ShouldContain(e => e.PropertyName == "NovaSenha" && e.ErrorMessage.Contains("mínimo 8 caracteres"));
+    }
+
+    [Fact]
+    public async Task Given_NovaSenhaESenhaAtualValidos_Should_PassarValidacao()
+    {
+        // Arrange
+        var request = new AtualizarPerfilRequest
+        {
+            Nome = "João Silva",
+            SenhaAtual = "senhaAtual123",
+            NovaSenha = "novaSenha123"
+        };
+
+        // Act
+        var resultado = await _sut.ValidateAsync(request);
+
+        // Assert
+        resultado.IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Given_SemNovaSenhaSemSenhaAtual_Should_PassarValidacao()
+    {
+        // Arrange
+        var request = new AtualizarPerfilRequest
+        {
+            Nome = "Maria Souza",
+            SenhaAtual = null,
+            NovaSenha = null
+        };
+
+        // Act
+        var resultado = await _sut.ValidateAsync(request);
+
+        // Assert
+        resultado.IsValid.ShouldBeTrue();
+    }
+}

--- a/backend/MapaTributario/tests/MapaTributario.Tests.Unit/PerfilControllerTests.cs
+++ b/backend/MapaTributario/tests/MapaTributario.Tests.Unit/PerfilControllerTests.cs
@@ -111,6 +111,20 @@ public class PerfilControllerTests
         notFound.Value!.ToString().ShouldContain("Usuário não encontrado");
     }
 
+    [Fact]
+    public async Task Given_UsuarioSemClaimDeId_ObterPerfil_Should_RetornarUnauthorized()
+    {
+        // Arrange
+        var sut = CriarSut(null);
+
+        // Act
+        var resultado = await sut.ObterPerfil();
+
+        // Assert
+        UnauthorizedObjectResult unauthorized = resultado.ShouldBeOfType<UnauthorizedObjectResult>();
+        unauthorized.Value!.ToString().ShouldContain("Usuário não identificado");
+    }
+
     // ── AtualizarPerfil (PUT) ───────────────────────────────────────
 
     [Fact]
@@ -200,5 +214,38 @@ public class PerfilControllerTests
         // Assert
         BadRequestObjectResult badRequest = resultado.ShouldBeOfType<BadRequestObjectResult>();
         badRequest.Value!.ToString().ShouldContain("Validação falhou");
+    }
+
+    [Fact]
+    public async Task Given_UsuarioSemClaimDeId_AtualizarPerfil_Should_RetornarUnauthorized()
+    {
+        // Arrange
+        var sut = CriarSut(null);
+        ConfigurarValidacaoComSucesso();
+        var request = new AtualizarPerfilRequest { Nome = "Novo Nome" };
+
+        // Act
+        var resultado = await sut.AtualizarPerfil(request, _atualizarValidator.Object);
+
+        // Assert
+        UnauthorizedObjectResult unauthorized = resultado.ShouldBeOfType<UnauthorizedObjectResult>();
+        unauthorized.Value!.ToString().ShouldContain("Usuário não identificado");
+    }
+
+    [Fact]
+    public async Task Given_UsuarioNaoEncontrado_AtualizarPerfil_Should_RetornarNotFound()
+    {
+        // Arrange
+        var sut = CriarSut();
+        ConfigurarValidacaoComSucesso();
+        _userRepository.Setup(r => r.GetByIdAsync(UsuarioId)).ReturnsAsync((User?)null);
+        var request = new AtualizarPerfilRequest { Nome = "Novo Nome" };
+
+        // Act
+        var resultado = await sut.AtualizarPerfil(request, _atualizarValidator.Object);
+
+        // Assert
+        NotFoundObjectResult notFound = resultado.ShouldBeOfType<NotFoundObjectResult>();
+        notFound.Value!.ToString().ShouldContain("Usuário não encontrado");
     }
 }

--- a/backend/MapaTributario/tests/MapaTributario.Tests.Unit/PerfilControllerTests.cs
+++ b/backend/MapaTributario/tests/MapaTributario.Tests.Unit/PerfilControllerTests.cs
@@ -1,0 +1,204 @@
+#pragma warning disable CS8604 // ToString() em objetos anônimos retorna string? mas nunca é null nos testes
+using System.Security.Claims;
+using FluentValidation;
+using FluentValidation.Results;
+using MapaTributario.API.Application.Perfil.Contracts;
+using MapaTributario.API.Controllers;
+using MapaTributario.API.Domain.Entities;
+using MapaTributario.API.Domain.Interfaces;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Shouldly;
+
+namespace MapaTributario.Tests.Unit;
+
+public class PerfilControllerTests
+{
+    private readonly Mock<IUserRepository> _userRepository = new();
+    private readonly Mock<ITokenProvider> _tokenProvider = new();
+    private readonly Mock<IPasswordHasher> _passwordHasher = new();
+    private readonly Mock<IValidator<AtualizarPerfilRequest>> _atualizarValidator = new();
+
+    private const string UsuarioId = "user-id-123";
+    private const string UsuarioEmail = "usuario@teste.com";
+    private const string UsuarioNome = "João Silva";
+    private const string SenhaHash = "hash-senha-atual";
+
+    public PerfilControllerTests()
+    {
+        _tokenProvider.Setup(x => x.GenerateAccessToken(It.IsAny<User>())).Returns("novo-access-token");
+        _passwordHasher.Setup(x => x.Hash(It.IsAny<string>())).Returns("novo-hash");
+    }
+
+    private PerfilController CriarSut(string? userId = UsuarioId)
+    {
+        var controller = new PerfilController(
+            _userRepository.Object,
+            _tokenProvider.Object,
+            _passwordHasher.Object);
+
+        var claims = new List<Claim>();
+        if (userId is not null)
+            claims.Add(new Claim(ClaimTypes.NameIdentifier, userId));
+
+        var identity = new ClaimsIdentity(claims, "TestAuth");
+        var claimsPrincipal = new ClaimsPrincipal(identity);
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { User = claimsPrincipal }
+        };
+
+        return controller;
+    }
+
+    private User CriarUsuario()
+    {
+        var usuario = User.Create(UsuarioEmail, UsuarioNome, SenhaHash);
+        usuario.SetId(UsuarioId);
+        return usuario;
+    }
+
+    private void ConfigurarValidacaoComSucesso()
+    {
+        _atualizarValidator.Setup(v => v.ValidateAsync(It.IsAny<AtualizarPerfilRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult());
+    }
+
+    private void ConfigurarValidacaoComFalha(string mensagemErro = "Campo obrigatório")
+    {
+        var resultado = new ValidationResult(new[]
+        {
+            new ValidationFailure("Campo", mensagemErro)
+        });
+        _atualizarValidator.Setup(v => v.ValidateAsync(It.IsAny<AtualizarPerfilRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(resultado);
+    }
+
+    // ── ObterPerfil (GET) ───────────────────────────────────────────
+
+    [Fact]
+    public async Task Given_UsuarioAutenticadoComIdValido_Should_RetornarOkComPerfilResponse()
+    {
+        // Arrange
+        var sut = CriarSut();
+        var usuario = CriarUsuario();
+        _userRepository.Setup(r => r.GetByIdAsync(UsuarioId)).ReturnsAsync(usuario);
+
+        // Act
+        var resultado = await sut.ObterPerfil();
+
+        // Assert
+        OkObjectResult ok = resultado.ShouldBeOfType<OkObjectResult>();
+        PerfilResponse perfil = ok.Value.ShouldBeOfType<PerfilResponse>();
+        perfil.Id.ShouldBe(UsuarioId);
+        perfil.Nome.ShouldBe(UsuarioNome);
+        perfil.Email.ShouldBe(UsuarioEmail);
+    }
+
+    [Fact]
+    public async Task Given_UsuarioNaoEncontrado_Should_RetornarNotFound()
+    {
+        // Arrange
+        var sut = CriarSut();
+        _userRepository.Setup(r => r.GetByIdAsync(UsuarioId)).ReturnsAsync((User?)null);
+
+        // Act
+        var resultado = await sut.ObterPerfil();
+
+        // Assert
+        NotFoundObjectResult notFound = resultado.ShouldBeOfType<NotFoundObjectResult>();
+        notFound.Value!.ToString().ShouldContain("Usuário não encontrado");
+    }
+
+    // ── AtualizarPerfil (PUT) ───────────────────────────────────────
+
+    [Fact]
+    public async Task Given_AtualizarSomenteNome_Should_RetornarOkComNovoToken()
+    {
+        // Arrange
+        var sut = CriarSut();
+        var usuario = CriarUsuario();
+        ConfigurarValidacaoComSucesso();
+        _userRepository.Setup(r => r.GetByIdAsync(UsuarioId)).ReturnsAsync(usuario);
+        _userRepository.Setup(r => r.AtualizarAsync(It.IsAny<User>())).Returns(Task.CompletedTask);
+        var request = new AtualizarPerfilRequest { Nome = "Novo Nome" };
+
+        // Act
+        var resultado = await sut.AtualizarPerfil(request, _atualizarValidator.Object);
+
+        // Assert
+        OkObjectResult ok = resultado.ShouldBeOfType<OkObjectResult>();
+        AtualizarPerfilResponse response = ok.Value.ShouldBeOfType<AtualizarPerfilResponse>();
+        response.Nome.ShouldBe("Novo Nome");
+        response.Email.ShouldBe(UsuarioEmail);
+        response.AccessToken.ShouldBe("novo-access-token");
+    }
+
+    [Fact]
+    public async Task Given_AtualizarNomeESenhaComSenhaAtualCorreta_Should_RetornarOk()
+    {
+        // Arrange
+        var sut = CriarSut();
+        var usuario = CriarUsuario();
+        ConfigurarValidacaoComSucesso();
+        _userRepository.Setup(r => r.GetByIdAsync(UsuarioId)).ReturnsAsync(usuario);
+        _userRepository.Setup(r => r.AtualizarAsync(It.IsAny<User>())).Returns(Task.CompletedTask);
+        _passwordHasher.Setup(p => p.Verify("senhaAtual123", SenhaHash)).Returns(true);
+        var request = new AtualizarPerfilRequest
+        {
+            Nome = "Novo Nome",
+            SenhaAtual = "senhaAtual123",
+            NovaSenha = "novaSenha456"
+        };
+
+        // Act
+        var resultado = await sut.AtualizarPerfil(request, _atualizarValidator.Object);
+
+        // Assert
+        OkObjectResult ok = resultado.ShouldBeOfType<OkObjectResult>();
+        AtualizarPerfilResponse response = ok.Value.ShouldBeOfType<AtualizarPerfilResponse>();
+        response.AccessToken.ShouldBe("novo-access-token");
+        _passwordHasher.Verify(p => p.Hash("novaSenha456"), Times.Once);
+    }
+
+    [Fact]
+    public async Task Given_SenhaAtualIncorreta_Should_RetornarBadRequest()
+    {
+        // Arrange
+        var sut = CriarSut();
+        var usuario = CriarUsuario();
+        ConfigurarValidacaoComSucesso();
+        _userRepository.Setup(r => r.GetByIdAsync(UsuarioId)).ReturnsAsync(usuario);
+        _passwordHasher.Setup(p => p.Verify("senhaErrada", SenhaHash)).Returns(false);
+        var request = new AtualizarPerfilRequest
+        {
+            Nome = "Novo Nome",
+            SenhaAtual = "senhaErrada",
+            NovaSenha = "novaSenha456"
+        };
+
+        // Act
+        var resultado = await sut.AtualizarPerfil(request, _atualizarValidator.Object);
+
+        // Assert
+        BadRequestObjectResult badRequest = resultado.ShouldBeOfType<BadRequestObjectResult>();
+        badRequest.Value!.ToString().ShouldContain("Senha atual incorreta");
+    }
+
+    [Fact]
+    public async Task Given_ValidacaoFalhaComNomeVazio_Should_RetornarBadRequestComDetalhes()
+    {
+        // Arrange
+        var sut = CriarSut();
+        ConfigurarValidacaoComFalha("Nome é obrigatório");
+        var request = new AtualizarPerfilRequest { Nome = "" };
+
+        // Act
+        var resultado = await sut.AtualizarPerfil(request, _atualizarValidator.Object);
+
+        // Assert
+        BadRequestObjectResult badRequest = resultado.ShouldBeOfType<BadRequestObjectResult>();
+        badRequest.Value!.ToString().ShouldContain("Validação falhou");
+    }
+}

--- a/backend/MapaTributario/tests/MapaTributario.Tests.Unit/UserTests.cs
+++ b/backend/MapaTributario/tests/MapaTributario.Tests.Unit/UserTests.cs
@@ -1,0 +1,82 @@
+using MapaTributario.API.Domain.Entities;
+using Shouldly;
+
+namespace MapaTributario.Tests.Unit;
+
+public class UserTests
+{
+    private User CriarUsuarioValido()
+    {
+        return User.Create("teste@teste.com", "Nome Original", "hash-original");
+    }
+
+    [Fact]
+    public void AtualizarNome_ComNomeValido_DeveAtualizarNome()
+    {
+        var usuario = CriarUsuarioValido();
+
+        usuario.AtualizarNome("Novo Nome");
+
+        usuario.Nome.ShouldBe("Novo Nome");
+    }
+
+    [Fact]
+    public void AtualizarNome_ComNomeVazio_DeveLancarExcecao()
+    {
+        var usuario = CriarUsuarioValido();
+
+        var excecao = Should.Throw<ArgumentException>(() => usuario.AtualizarNome(""));
+
+        excecao.ParamName.ShouldBe("nome");
+    }
+
+    [Fact]
+    public void AtualizarNome_ComNomeNulo_DeveLancarExcecao()
+    {
+        var usuario = CriarUsuarioValido();
+
+        var excecao = Should.Throw<ArgumentException>(() => usuario.AtualizarNome(null!));
+
+        excecao.ParamName.ShouldBe("nome");
+    }
+
+    [Fact]
+    public void AtualizarNome_ComEspacosEmBranco_DeveLancarExcecao()
+    {
+        var usuario = CriarUsuarioValido();
+
+        var excecao = Should.Throw<ArgumentException>(() => usuario.AtualizarNome("   "));
+
+        excecao.ParamName.ShouldBe("nome");
+    }
+
+    [Fact]
+    public void AtualizarSenha_ComHashValido_DeveAtualizarPasswordHash()
+    {
+        var usuario = CriarUsuarioValido();
+
+        usuario.AtualizarSenha("novo-hash");
+
+        usuario.PasswordHash.ShouldBe("novo-hash");
+    }
+
+    [Fact]
+    public void AtualizarSenha_ComHashVazio_DeveLancarExcecao()
+    {
+        var usuario = CriarUsuarioValido();
+
+        var excecao = Should.Throw<ArgumentException>(() => usuario.AtualizarSenha(""));
+
+        excecao.ParamName.ShouldBe("novoHash");
+    }
+
+    [Fact]
+    public void AtualizarSenha_ComHashNulo_DeveLancarExcecao()
+    {
+        var usuario = CriarUsuarioValido();
+
+        var excecao = Should.Throw<ArgumentException>(() => usuario.AtualizarSenha(null!));
+
+        excecao.ParamName.ShouldBe("novoHash");
+    }
+}

--- a/cypress/e2e/auth.cy.ts
+++ b/cypress/e2e/auth.cy.ts
@@ -166,8 +166,9 @@ describe('Autenticação', () => {
       cy.visit('/consulta');
       cy.getByDataCy('consulta-page').should('be.visible');
 
-      // Act
-      cy.getByDataCy('logout-button').click();
+      // Act — abrir popover do menu de usuário e clicar em Sair
+      cy.getByDataCy('user-menu-trigger').click();
+      cy.getByDataCy('menu-sair').click();
 
       // Assert
       cy.url().should('include', '/auth/login');

--- a/cypress/e2e/perfil.cy.ts
+++ b/cypress/e2e/perfil.cy.ts
@@ -1,0 +1,173 @@
+// ---------------------------------------------------------------------------
+// perfil.cy.ts — Testes E2E do perfil de usuário
+// ---------------------------------------------------------------------------
+
+describe('Perfil de Usuário', () => {
+  const nomeOriginal = 'Admin';
+  const senhaAtual = '12345678';
+
+  beforeEach(() => {
+    cy.login();
+    cy.visit('/consulta');
+    cy.getByDataCy('consulta-page').should('be.visible');
+  });
+
+  describe('Navegação via Dropdown da Topbar', () => {
+    it('Given_UsuarioAutenticado_Should_ExibirDropdownComMeuPerfilELogout', () => {
+      // Act — abrir popover do menu de usuário
+      cy.getByDataCy('user-menu-trigger').click();
+
+      // Assert
+      cy.getByDataCy('menu-meu-perfil').should('be.visible');
+      cy.getByDataCy('menu-sair').should('be.visible');
+    });
+
+    it('Given_CliqueEmMeuPerfil_Should_NavegarParaPaginaDePerfil', () => {
+      // Act
+      cy.getByDataCy('user-menu-trigger').click();
+      cy.getByDataCy('menu-meu-perfil').click();
+
+      // Assert
+      cy.url().should('include', '/perfil');
+      cy.getByDataCy('perfil-page').should('be.visible');
+    });
+  });
+
+  describe('Visualização do Perfil', () => {
+    beforeEach(() => {
+      cy.visit('/perfil');
+      cy.getByDataCy('perfil-page').should('be.visible');
+    });
+
+    it('Given_PaginaDePerfil_Should_ExibirNomeEEmailDoUsuario', () => {
+      // Assert
+      cy.getByDataCy('perfil-nome').should('be.visible');
+      cy.getByDataCy('perfil-nome').should('not.have.value', '');
+      cy.getByDataCy('perfil-email').should('be.visible');
+      cy.getByDataCy('perfil-email').should('have.value', 'admin@admin.com');
+    });
+
+    it('Given_PaginaDePerfil_Should_ExibirEmailComoSomenteLeitura', () => {
+      // Assert
+      cy.getByDataCy('perfil-email').should('have.attr', 'readonly');
+    });
+  });
+
+  describe('Edição de Nome', () => {
+    const nomeAlterado = `Teste E2E ${Date.now()}`;
+
+    beforeEach(() => {
+      cy.visit('/perfil');
+      cy.getByDataCy('perfil-page').should('be.visible');
+    });
+
+    it('Given_NomeValido_Should_AtualizarNomeEExibirMensagemDeSucesso', () => {
+      // Act
+      cy.getByDataCy('perfil-nome').clear().type(nomeAlterado);
+      cy.getByDataCy('perfil-salvar').click();
+
+      // Assert — mensagem de sucesso
+      cy.contains('Perfil atualizado com sucesso').should('be.visible');
+
+      // Assert — topbar deve refletir o novo nome
+      cy.getByDataCy('user-name').should('contain.text', nomeAlterado);
+    });
+
+    it('Given_NomeVazio_Should_ExibirErroDeValidacao', () => {
+      // Act
+      cy.getByDataCy('perfil-nome').clear();
+      cy.getByDataCy('perfil-salvar').click();
+
+      // Assert
+      cy.contains('Nome é obrigatório').should('be.visible');
+    });
+
+    afterEach(() => {
+      // Restaurar nome original via API para não afetar outros testes
+      cy.window().then((win) => {
+        const token = win.localStorage.getItem('accessToken');
+        if (token) {
+          cy.request({
+            method: 'PUT',
+            url: '/api/v1/perfil',
+            headers: { Authorization: `Bearer ${token}` },
+            body: { nome: nomeOriginal },
+          });
+        }
+      });
+    });
+  });
+
+  describe('Alteração de Senha', () => {
+    beforeEach(() => {
+      cy.visit('/perfil');
+      cy.getByDataCy('perfil-page').should('be.visible');
+    });
+
+    it('Given_SenhaAtualCorretaENovaSenhaValida_Should_AlterarSenhaComSucesso', () => {
+      const novaSenha = 'novaSenha123';
+
+      // Act — alterar senha
+      cy.get('[data-cy="perfil-senha-atual"] input').clear().type(senhaAtual);
+      cy.get('[data-cy="perfil-nova-senha"] input').clear().type(novaSenha);
+      cy.get('[data-cy="perfil-confirmar-nova-senha"] input').clear().type(novaSenha);
+      cy.getByDataCy('perfil-salvar').click();
+
+      // Assert
+      cy.contains('Perfil atualizado com sucesso').should('be.visible');
+
+      // Restaurar — alterar senha de volta para a original
+      cy.get('[data-cy="perfil-senha-atual"] input').clear().type(novaSenha);
+      cy.get('[data-cy="perfil-nova-senha"] input').clear().type(senhaAtual);
+      cy.get('[data-cy="perfil-confirmar-nova-senha"] input').clear().type(senhaAtual);
+      cy.getByDataCy('perfil-salvar').click();
+      cy.contains('Perfil atualizado com sucesso').should('be.visible');
+    });
+
+    it('Given_SenhaAtualIncorreta_Should_ExibirMensagemDeErro', () => {
+      // Act
+      cy.get('[data-cy="perfil-senha-atual"] input').clear().type('senhaErrada');
+      cy.get('[data-cy="perfil-nova-senha"] input').clear().type('novaSenha123');
+      cy.get('[data-cy="perfil-confirmar-nova-senha"] input').clear().type('novaSenha123');
+      cy.getByDataCy('perfil-salvar').click();
+
+      // Assert
+      cy.contains('Senha atual incorreta').should('be.visible');
+    });
+
+    it('Given_NovaSenhaCurtaDemais_Should_ExibirErroDeValidacao', () => {
+      // Act — preencher senha atual mas nova senha com menos de 8 caracteres
+      cy.get('[data-cy="perfil-senha-atual"] input').clear().type(senhaAtual);
+      cy.get('[data-cy="perfil-nova-senha"] input').clear().type('curta');
+      cy.get('[data-cy="perfil-confirmar-nova-senha"] input').clear().type('curta');
+      cy.getByDataCy('perfil-salvar').click();
+
+      // Assert — backend retorna erro de validação (min 8 chars)
+      cy.contains(/senha|mínimo|caracteres/i).should('be.visible');
+    });
+
+    it('Given_SenhasNaoCoincidem_Should_ExibirErroDeValidacao', () => {
+      // Act — nova senha e confirmação diferentes
+      cy.get('[data-cy="perfil-senha-atual"] input').clear().type(senhaAtual);
+      cy.get('[data-cy="perfil-nova-senha"] input').clear().type('novaSenha123');
+      cy.get('[data-cy="perfil-confirmar-nova-senha"] input').clear().type('senhaDiferente');
+      cy.getByDataCy('perfil-salvar').click();
+
+      // Assert
+      cy.contains('As senhas não coincidem').should('be.visible');
+    });
+  });
+
+  describe('Proteção de Rota', () => {
+    it('Given_UsuarioNaoAutenticado_Should_RedirecionarParaLoginAoAcessarPerfil', () => {
+      // Arrange — limpar autenticação
+      cy.logout();
+
+      // Act
+      cy.visit('/perfil');
+
+      // Assert
+      cy.url().should('include', '/auth/login');
+    });
+  });
+});

--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -12,6 +12,9 @@
   - [POST /api/v1/auth/register](#post-apiv1authregister)
   - [POST /api/v1/auth/login](#post-apiv1authlogin)
   - [POST /api/v1/auth/refresh](#post-apiv1authrefresh)
+- [Perfil do Usuario](#perfil-do-usuario)
+  - [GET /api/v1/perfil](#get-apiv1perfil)
+  - [PUT /api/v1/perfil](#put-apiv1perfil)
 - [Consulta de Dados](#consulta-de-dados)
   - [GET /api/v1/estados](#get-apiv1estados)
   - [GET /api/v1/estados/:uf/municipios](#get-apiv1estadosufmunicipios)
@@ -268,6 +271,179 @@ Content-Type: application/json
   "accessToken": "eyJhbGciOiJIUzI1NiIs...(novo token)",
   "refreshToken": "dGhpcyBpcyBhIG5vdm8gcmVm...(novo refresh)",
   "expiresIn": 3600
+}
+```
+
+---
+
+## Perfil do Usuario
+
+Endpoints protegidos para visualizacao e edicao do perfil do usuario autenticado.
+
+---
+
+### GET /api/v1/perfil
+
+Retorna os dados do perfil do usuario autenticado.
+
+**Autenticacao:** JWT Bearer (obrigatorio)
+
+**Parametros:** Nenhum
+
+**Respostas:**
+
+| Status | Descricao |
+|--------|-----------|
+| 200 OK | Dados do perfil retornados com sucesso |
+| 401 Unauthorized | Token ausente ou invalido |
+
+**Response Body (200):**
+
+```json
+{
+  "id": "string",
+  "nome": "string",
+  "email": "string"
+}
+```
+
+| Campo | Tipo | Descricao |
+|-------|------|-----------|
+| id | string | Identificador unico do usuario (ObjectId) |
+| nome | string | Nome do usuario |
+| email | string | Email do usuario |
+
+**Exemplo de requisicao:**
+
+```http
+GET /api/v1/perfil HTTP/1.1
+Authorization: Bearer eyJhbGciOiJIUzI1NiIs...
+```
+
+**Exemplo de resposta (200):**
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "id": "660f1a2b3c4d5e6f7a8b9c0d",
+  "nome": "Maria Silva",
+  "email": "maria@exemplo.com"
+}
+```
+
+---
+
+### PUT /api/v1/perfil
+
+Atualiza o perfil do usuario autenticado. Permite alterar o nome e, opcionalmente, a senha.
+
+**Autenticacao:** JWT Bearer (obrigatorio)
+
+**Request Body:**
+
+```json
+{
+  "nome": "string (required, min 2 caracteres)",
+  "senhaAtual": "string (required se novaSenha informada)",
+  "novaSenha": "string (optional, min 8 caracteres)"
+}
+```
+
+| Campo | Tipo | Obrigatorio | Descricao |
+|-------|------|-------------|-----------|
+| nome | string | Sim | Novo nome do usuario (min 2 caracteres) |
+| senhaAtual | string | Condicional | Senha atual para verificacao. Obrigatoria quando `novaSenha` e informada |
+| novaSenha | string | Nao | Nova senha desejada (min 8 caracteres). Se omitida ou vazia, a senha nao e alterada |
+
+> **Nota:** Se apenas `nome` for informado (sem `senhaAtual` e `novaSenha`), somente o nome e atualizado. Se `novaSenha` for informada, `senhaAtual` e obrigatoria para validacao.
+
+**Respostas:**
+
+| Status | Descricao |
+|--------|-----------|
+| 200 OK | Perfil atualizado com sucesso |
+| 400 Bad Request | Validacao falhou ou senha atual incorreta |
+| 401 Unauthorized | Token ausente ou invalido |
+
+**Response Body (200):**
+
+```json
+{
+  "id": "string",
+  "nome": "string",
+  "email": "string",
+  "accessToken": "string (JWT)"
+}
+```
+
+| Campo | Tipo | Descricao |
+|-------|------|-----------|
+| id | string | Identificador unico do usuario |
+| nome | string | Nome atualizado |
+| email | string | Email do usuario (nao alteravel) |
+| accessToken | string | Novo JWT contendo o nome atualizado nos claims |
+
+> **Nota:** O endpoint retorna um novo `accessToken` para que o frontend atualize imediatamente o nome exibido na topbar sem necessidade de re-login.
+
+**Response Body (400 — validacao):**
+
+```json
+{
+  "erro": "Validacao falhou",
+  "detalhes": [
+    "Nome e obrigatorio",
+    "Nova senha deve ter no minimo 8 caracteres"
+  ]
+}
+```
+
+**Response Body (400 — senha incorreta):**
+
+```json
+{
+  "erro": "Senha atual incorreta"
+}
+```
+
+**Exemplo de requisicao (somente nome):**
+
+```http
+PUT /api/v1/perfil HTTP/1.1
+Authorization: Bearer eyJhbGciOiJIUzI1NiIs...
+Content-Type: application/json
+
+{
+  "nome": "Maria Silva Atualizada"
+}
+```
+
+**Exemplo de requisicao (nome + senha):**
+
+```http
+PUT /api/v1/perfil HTTP/1.1
+Authorization: Bearer eyJhbGciOiJIUzI1NiIs...
+Content-Type: application/json
+
+{
+  "nome": "Maria Silva",
+  "senhaAtual": "MinhaSenh@123",
+  "novaSenha": "NovaSenha@456"
+}
+```
+
+**Exemplo de resposta (200):**
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "id": "660f1a2b3c4d5e6f7a8b9c0d",
+  "nome": "Maria Silva Atualizada",
+  "email": "maria@exemplo.com",
+  "accessToken": "eyJhbGciOiJIUzI1NiIs...(novo token com nome atualizado)"
 }
 ```
 

--- a/frontend/MapaTributario-ui/src/app/app.routes.ts
+++ b/frontend/MapaTributario-ui/src/app/app.routes.ts
@@ -24,6 +24,12 @@ export const routes: Routes = [
         loadChildren: () =>
           import('./features/admin/admin.routes').then((m) => m.ADMIN_ROUTES),
       },
+      {
+        path: 'perfil',
+        canActivate: [authGuard],
+        loadComponent: () =>
+          import('./features/perfil/perfil.component').then((m) => m.PerfilComponent),
+      },
     ],
   },
   {

--- a/frontend/MapaTributario-ui/src/app/core/auth/auth.service.spec.ts
+++ b/frontend/MapaTributario-ui/src/app/core/auth/auth.service.spec.ts
@@ -229,6 +229,31 @@ describe('AuthService', () => {
 
       expect(service.userName()).toBe('email@test.com');
     });
+
+    it('deve atualizar token no sessionStorage quando token original esta em sessionStorage', () => {
+      localStorage.setItem('rememberMe', 'false');
+      sessionStorage.setItem('accessToken', 'token-antigo');
+      const novoPayload = { ...validPayload, 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name': 'Nome Session' };
+      const novoToken = makeJwt(novoPayload);
+
+      service.atualizarToken(novoToken);
+
+      expect(sessionStorage.getItem('accessToken')).toBe(novoToken);
+      expect(localStorage.getItem('accessToken')).toBeNull();
+      expect(service.userName()).toBe('Nome Session');
+    });
+
+    it('deve atualizar token no localStorage quando token original esta em localStorage', () => {
+      localStorage.setItem('rememberMe', 'false');
+      localStorage.setItem('accessToken', 'token-antigo-local');
+      const novoPayload = { ...validPayload, 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name': 'Nome Local' };
+      const novoToken = makeJwt(novoPayload);
+
+      service.atualizarToken(novoToken);
+
+      expect(localStorage.getItem('accessToken')).toBe(novoToken);
+      expect(service.userName()).toBe('Nome Local');
+    });
   });
 
   describe('token decode', () => {

--- a/frontend/MapaTributario-ui/src/app/core/auth/auth.service.spec.ts
+++ b/frontend/MapaTributario-ui/src/app/core/auth/auth.service.spec.ts
@@ -204,6 +204,33 @@ describe('AuthService', () => {
     });
   });
 
+  describe('atualizarToken', () => {
+    it('deve atualizar token local e userName', () => {
+      localStorage.setItem('rememberMe', 'true');
+      const novoPayload = { ...validPayload, 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name': 'Nome Atualizado' };
+      const novoToken = makeJwt(novoPayload);
+
+      service.atualizarToken(novoToken);
+
+      expect(service.getAccessToken()).toBe(novoToken);
+      expect(service.userName()).toBe('Nome Atualizado');
+    });
+
+    it('deve preservar userName de email quando name nao existe no token', () => {
+      localStorage.setItem('rememberMe', 'true');
+      const payloadSemNome = {
+        'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier': 'user-123',
+        'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress': 'email@test.com',
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      };
+      const token = makeJwt(payloadSemNome);
+
+      service.atualizarToken(token);
+
+      expect(service.userName()).toBe('email@test.com');
+    });
+  });
+
   describe('token decode', () => {
     it('deve extrair userName de claims padrao quando claims .NET nao existem', () => {
       const stdPayload = { sub: 'u1', email: 'std@test.com', name: 'Std User', exp: Math.floor(Date.now() / 1000) + 3600 };

--- a/frontend/MapaTributario-ui/src/app/core/auth/auth.service.ts
+++ b/frontend/MapaTributario-ui/src/app/core/auth/auth.service.ts
@@ -95,6 +95,11 @@ export class AuthService {
     this._refreshInProgress = value;
   }
 
+  atualizarToken(novoToken: string): void {
+    this._setItem('accessToken', novoToken);
+    this._updateUserFromToken(novoToken);
+  }
+
   private _handleAuthSuccess(authResponse: AuthResponse): void {
     this._setItem('accessToken', authResponse.accessToken);
     this._setItem('refreshToken', authResponse.refreshToken);

--- a/frontend/MapaTributario-ui/src/app/core/auth/auth.service.ts
+++ b/frontend/MapaTributario-ui/src/app/core/auth/auth.service.ts
@@ -96,7 +96,7 @@ export class AuthService {
   }
 
   atualizarToken(novoToken: string): void {
-    this._setItem('accessToken', novoToken);
+    this._atualizarTokenNoStorageCorreto('accessToken', novoToken);
     this._updateUserFromToken(novoToken);
   }
 
@@ -174,6 +174,17 @@ export class AuthService {
   private _setRemember(lembrar: boolean): void {
     if (isPlatformBrowser(this._platformId)) {
       localStorage.setItem('rememberMe', String(lembrar));
+    }
+  }
+
+  private _atualizarTokenNoStorageCorreto(chave: string, valor: string): void {
+    if (!isPlatformBrowser(this._platformId)) return;
+    if (localStorage.getItem(chave) !== null) {
+      localStorage.setItem(chave, valor);
+    } else if (sessionStorage.getItem(chave) !== null) {
+      sessionStorage.setItem(chave, valor);
+    } else {
+      this._setItem(chave, valor);
     }
   }
 }

--- a/frontend/MapaTributario-ui/src/app/features/perfil/perfil.component.html
+++ b/frontend/MapaTributario-ui/src/app/features/perfil/perfil.component.html
@@ -27,7 +27,7 @@
 
           <div>
             <label for="email" class="block font-medium mb-2">Email</label>
-            <input pInputText id="email" formControlName="email" class="w-full" data-cy="perfil-email" />
+            <input pInputText id="email" formControlName="email" class="w-full" data-cy="perfil-email" readonly />
             <small class="text-muted-color block mt-1">O email não pode ser alterado.</small>
           </div>
 

--- a/frontend/MapaTributario-ui/src/app/features/perfil/perfil.component.html
+++ b/frontend/MapaTributario-ui/src/app/features/perfil/perfil.component.html
@@ -1,0 +1,63 @@
+<div class="perfil-container flex justify-center p-6" data-cy="perfil-page">
+  <p-card header="Meu Perfil" styleClass="w-full max-w-2xl">
+    @if (carregando()) {
+      <div class="flex justify-center p-8">
+        <i class="pi pi-spinner pi-spin text-4xl"></i>
+      </div>
+    } @else {
+      @if (mensagemSucesso()) {
+        <p-message severity="success" [text]="mensagemSucesso()" styleClass="w-full mb-4" />
+      }
+      @if (mensagemErro()) {
+        <p-message severity="error" [text]="mensagemErro()" styleClass="w-full mb-4" />
+      }
+
+      <form [formGroup]="form" (ngSubmit)="onSubmit()">
+        <div class="flex flex-col gap-4">
+          <div>
+            <label for="nome" class="block font-medium mb-2">Nome</label>
+            <input pInputText id="nome" formControlName="nome" class="w-full" data-cy="perfil-nome" />
+            @if (form.controls.nome.touched && form.controls.nome.errors) {
+              <small class="text-red-500 block mt-1">
+                @if (form.controls.nome.errors['required']) { Nome é obrigatório. }
+                @else if (form.controls.nome.errors['minlength']) { Nome deve ter pelo menos 2 caracteres. }
+              </small>
+            }
+          </div>
+
+          <div>
+            <label for="email" class="block font-medium mb-2">Email</label>
+            <input pInputText id="email" formControlName="email" class="w-full" data-cy="perfil-email" />
+            <small class="text-muted-color block mt-1">O email não pode ser alterado.</small>
+          </div>
+
+          <p-divider />
+
+          <h3 class="text-lg font-medium m-0">Alterar Senha <span class="text-muted-color text-sm font-normal">(opcional)</span></h3>
+
+          <div>
+            <label for="senhaAtual" class="block font-medium mb-2">Senha Atual</label>
+            <p-password id="senhaAtual" formControlName="senhaAtual" [toggleMask]="true" [fluid]="true" [feedback]="false" data-cy="perfil-senha-atual" />
+          </div>
+
+          <div>
+            <label for="novaSenha" class="block font-medium mb-2">Nova Senha</label>
+            <p-password id="novaSenha" formControlName="novaSenha" [toggleMask]="true" [fluid]="true" [feedback]="false" data-cy="perfil-nova-senha" />
+          </div>
+
+          <div>
+            <label for="confirmarNovaSenha" class="block font-medium mb-2">Confirmar Nova Senha</label>
+            <p-password id="confirmarNovaSenha" formControlName="confirmarNovaSenha" [toggleMask]="true" [fluid]="true" [feedback]="false" data-cy="perfil-confirmar-nova-senha" />
+            @if (form.hasError('senhasNaoConferem') && form.controls.confirmarNovaSenha.touched) {
+              <small class="text-red-500 block mt-1">As senhas não coincidem.</small>
+            }
+          </div>
+        </div>
+
+        <div class="flex justify-end mt-6">
+          <p-button type="submit" label="Salvar" icon="pi pi-check" [loading]="salvando()" [disabled]="salvando()" data-cy="perfil-salvar" />
+        </div>
+      </form>
+    }
+  </p-card>
+</div>

--- a/frontend/MapaTributario-ui/src/app/features/perfil/perfil.component.scss
+++ b/frontend/MapaTributario-ui/src/app/features/perfil/perfil.component.scss
@@ -1,0 +1,4 @@
+.perfil-container {
+  min-height: calc(100vh - 10rem);
+  align-items: flex-start;
+}

--- a/frontend/MapaTributario-ui/src/app/features/perfil/perfil.component.spec.ts
+++ b/frontend/MapaTributario-ui/src/app/features/perfil/perfil.component.spec.ts
@@ -1,0 +1,202 @@
+import { render, screen, fireEvent } from '@testing-library/angular';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideRouter } from '@angular/router';
+import { TestBed } from '@angular/core/testing';
+import { PLATFORM_ID } from '@angular/core';
+import { PerfilComponent } from './perfil.component';
+import { AuthService } from '../../core/auth/auth.service';
+
+function makeJwt(payload: Record<string, unknown>): string {
+  const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const body = btoa(JSON.stringify(payload));
+  return `${header}.${body}.fake-signature`;
+}
+
+const validPayload = {
+  'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier': 'user-123',
+  'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress': 'teste@test.com',
+  'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name': 'Nome Atualizado',
+  exp: Math.floor(Date.now() / 1000) + 3600,
+};
+
+const perfilMock = { id: '123', nome: 'João Silva', email: 'joao@test.com' };
+
+describe('PerfilComponent', () => {
+  let httpTesting: HttpTestingController;
+
+  async function setup() {
+    const result = await render(PerfilComponent, {
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideRouter([{ path: 'auth/login', component: {} as any }]),
+        { provide: PLATFORM_ID, useValue: 'browser' },
+      ],
+    });
+    httpTesting = TestBed.inject(HttpTestingController);
+    const authService = TestBed.inject(AuthService);
+    return { ...result, authService };
+  }
+
+  afterEach(() => {
+    httpTesting.verify();
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  it('deve exibir spinner enquanto carrega', async () => {
+    const { container } = await setup();
+    expect(container.querySelector('.pi-spinner')).toBeTruthy();
+
+    // Finalizar a requisição pendente
+    httpTesting.expectOne('/api/v1/perfil').flush(perfilMock);
+  });
+
+  it('deve carregar e exibir dados do perfil', async () => {
+    const { container } = await setup();
+
+    httpTesting.expectOne('/api/v1/perfil').flush(perfilMock);
+    await new Promise(r => setTimeout(r, 0));
+
+    const nomeInput = container.querySelector('[data-cy="perfil-nome"]') as HTMLInputElement;
+    const emailInput = container.querySelector('[data-cy="perfil-email"]') as HTMLInputElement;
+
+    expect(nomeInput).toBeTruthy();
+    expect(nomeInput.value).toBe('João Silva');
+    expect(emailInput).toBeTruthy();
+    expect(emailInput.value).toBe('joao@test.com');
+    expect(emailInput.disabled).toBe(true);
+  });
+
+  it('deve exibir mensagem de erro ao falhar ao carregar perfil', async () => {
+    await setup();
+
+    httpTesting.expectOne('/api/v1/perfil').flush(
+      { erro: 'Erro' },
+      { status: 500, statusText: 'Internal Server Error' },
+    );
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(screen.getByText('Erro ao carregar perfil. Tente novamente.')).toBeTruthy();
+  });
+
+  it('deve atualizar perfil com sucesso e atualizar token', async () => {
+    localStorage.setItem('rememberMe', 'true');
+    const { container, authService } = await setup();
+    const espiao = vi.spyOn(authService, 'atualizarToken');
+
+    httpTesting.expectOne('/api/v1/perfil').flush(perfilMock);
+    await new Promise(r => setTimeout(r, 0));
+
+    // Alterar nome
+    const nomeInput = container.querySelector('[data-cy="perfil-nome"]') as HTMLInputElement;
+    fireEvent.input(nomeInput, { target: { value: 'Nome Atualizado' } });
+
+    // Submeter
+    const form = container.querySelector('form') as HTMLFormElement;
+    fireEvent.submit(form);
+
+    const novoToken = makeJwt(validPayload);
+    const respostaMock = { id: '123', nome: 'Nome Atualizado', email: 'joao@test.com', accessToken: novoToken };
+    httpTesting.expectOne({ method: 'PUT', url: '/api/v1/perfil' }).flush(respostaMock);
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(espiao).toHaveBeenCalledWith(novoToken);
+    expect(screen.getByText('Perfil atualizado com sucesso!')).toBeTruthy();
+  });
+
+  it('deve exibir erro ao tentar alterar senha sem informar senha atual', async () => {
+    const { container } = await setup();
+
+    httpTesting.expectOne('/api/v1/perfil').flush(perfilMock);
+    await new Promise(r => setTimeout(r, 0));
+
+    // Preencher apenas nova senha e confirmação (sem senha atual)
+    const novaSenhaInput = container.querySelector('[data-cy="perfil-nova-senha"] input') as HTMLInputElement;
+    const confirmarInput = container.querySelector('[data-cy="perfil-confirmar-nova-senha"] input') as HTMLInputElement;
+    if (novaSenhaInput) {
+      fireEvent.input(novaSenhaInput, { target: { value: 'novaSenha123' } });
+    }
+    if (confirmarInput) {
+      fireEvent.input(confirmarInput, { target: { value: 'novaSenha123' } });
+    }
+
+    const form = container.querySelector('form') as HTMLFormElement;
+    fireEvent.submit(form);
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(screen.getByText('Informe a senha atual para alterar a senha.')).toBeTruthy();
+  });
+
+  it('deve exibir erro quando senhas não coincidem', async () => {
+    const { container } = await setup();
+
+    httpTesting.expectOne('/api/v1/perfil').flush(perfilMock);
+    await new Promise(r => setTimeout(r, 0));
+
+    // Preencher senha atual, nova senha e confirmação diferente
+    const senhaAtualInput = container.querySelector('[data-cy="perfil-senha-atual"] input') as HTMLInputElement;
+    const novaSenhaInput = container.querySelector('[data-cy="perfil-nova-senha"] input') as HTMLInputElement;
+    const confirmarInput = container.querySelector('[data-cy="perfil-confirmar-nova-senha"] input') as HTMLInputElement;
+    if (senhaAtualInput) {
+      fireEvent.input(senhaAtualInput, { target: { value: '12345678' } });
+    }
+    if (novaSenhaInput) {
+      fireEvent.input(novaSenhaInput, { target: { value: 'novaSenha123' } });
+    }
+    if (confirmarInput) {
+      fireEvent.input(confirmarInput, { target: { value: 'senhaDiferente' } });
+    }
+
+    const form = container.querySelector('form') as HTMLFormElement;
+    fireEvent.submit(form);
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(screen.getAllByText('As senhas não coincidem.').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('deve exibir erro quando API retorna 400', async () => {
+    const { container } = await setup();
+
+    httpTesting.expectOne('/api/v1/perfil').flush(perfilMock);
+    await new Promise(r => setTimeout(r, 0));
+
+    const form = container.querySelector('form') as HTMLFormElement;
+    fireEvent.submit(form);
+
+    httpTesting.expectOne({ method: 'PUT', url: '/api/v1/perfil' }).flush(
+      { erro: 'Senha atual incorreta' },
+      { status: 400, statusText: 'Bad Request' },
+    );
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(screen.getByText('Senha atual incorreta')).toBeTruthy();
+  });
+
+  it('deve exibir erro generico quando API retorna 500', async () => {
+    const { container } = await setup();
+
+    httpTesting.expectOne('/api/v1/perfil').flush(perfilMock);
+    await new Promise(r => setTimeout(r, 0));
+
+    const form = container.querySelector('form') as HTMLFormElement;
+    fireEvent.submit(form);
+
+    httpTesting.expectOne({ method: 'PUT', url: '/api/v1/perfil' }).flush(
+      {},
+      { status: 500, statusText: 'Internal Server Error' },
+    );
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(screen.getByText('Erro ao atualizar perfil. Tente novamente.')).toBeTruthy();
+  });
+
+  it('deve exibir titulo Meu Perfil', async () => {
+    await setup();
+    httpTesting.expectOne('/api/v1/perfil').flush(perfilMock);
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(screen.getByText('Meu Perfil')).toBeTruthy();
+  });
+});

--- a/frontend/MapaTributario-ui/src/app/features/perfil/perfil.component.spec.ts
+++ b/frontend/MapaTributario-ui/src/app/features/perfil/perfil.component.spec.ts
@@ -66,7 +66,7 @@ describe('PerfilComponent', () => {
     expect(nomeInput.value).toBe('João Silva');
     expect(emailInput).toBeTruthy();
     expect(emailInput.value).toBe('joao@test.com');
-    expect(emailInput.disabled).toBe(true);
+    expect(emailInput.readOnly).toBe(true);
   });
 
   it('deve exibir mensagem de erro ao falhar ao carregar perfil', async () => {

--- a/frontend/MapaTributario-ui/src/app/features/perfil/perfil.component.spec.ts
+++ b/frontend/MapaTributario-ui/src/app/features/perfil/perfil.component.spec.ts
@@ -199,4 +199,138 @@ describe('PerfilComponent', () => {
 
     expect(screen.getByText('Meu Perfil')).toBeTruthy();
   });
+
+  it('deve exibir erro ao informar senha atual sem nova senha', async () => {
+    const { container } = await setup();
+
+    httpTesting.expectOne('/api/v1/perfil').flush(perfilMock);
+    await new Promise(r => setTimeout(r, 0));
+
+    // Preencher apenas senha atual (sem nova senha)
+    const senhaAtualInput = container.querySelector('[data-cy="perfil-senha-atual"] input') as HTMLInputElement;
+    if (senhaAtualInput) {
+      fireEvent.input(senhaAtualInput, { target: { value: '12345678' } });
+    }
+
+    const form = container.querySelector('form') as HTMLFormElement;
+    fireEvent.submit(form);
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(screen.getByText('Informe a nova senha.')).toBeTruthy();
+  });
+
+  it('deve exibir erro quando API retorna 400 com detalhes array', async () => {
+    const { container } = await setup();
+
+    httpTesting.expectOne('/api/v1/perfil').flush(perfilMock);
+    await new Promise(r => setTimeout(r, 0));
+
+    const form = container.querySelector('form') as HTMLFormElement;
+    fireEvent.submit(form);
+
+    httpTesting.expectOne({ method: 'PUT', url: '/api/v1/perfil' }).flush(
+      { detalhes: ['Campo nome é obrigatório', 'Senha muito curta'] },
+      { status: 400, statusText: 'Bad Request' },
+    );
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(screen.getByText('Campo nome é obrigatório, Senha muito curta')).toBeTruthy();
+  });
+
+  it('deve exibir erro generico quando API retorna 400 sem erro e sem detalhes', async () => {
+    const { container } = await setup();
+
+    httpTesting.expectOne('/api/v1/perfil').flush(perfilMock);
+    await new Promise(r => setTimeout(r, 0));
+
+    const form = container.querySelector('form') as HTMLFormElement;
+    fireEvent.submit(form);
+
+    httpTesting.expectOne({ method: 'PUT', url: '/api/v1/perfil' }).flush(
+      {},
+      { status: 400, statusText: 'Bad Request' },
+    );
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(screen.getByText('Dados inválidos. Verifique os campos.')).toBeTruthy();
+  });
+
+  it('deve exibir erro de sessao expirada quando API retorna 401', async () => {
+    const { container } = await setup();
+
+    httpTesting.expectOne('/api/v1/perfil').flush(perfilMock);
+    await new Promise(r => setTimeout(r, 0));
+
+    const form = container.querySelector('form') as HTMLFormElement;
+    fireEvent.submit(form);
+
+    httpTesting.expectOne({ method: 'PUT', url: '/api/v1/perfil' }).flush(
+      {},
+      { status: 401, statusText: 'Unauthorized' },
+    );
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(screen.getByText('Sessão expirada. Faça login novamente.')).toBeTruthy();
+  });
+
+  it('deve exibir validacao de nome obrigatorio ao submeter com nome vazio', async () => {
+    const { container } = await setup();
+
+    httpTesting.expectOne('/api/v1/perfil').flush(perfilMock);
+    await new Promise(r => setTimeout(r, 0));
+
+    // Limpar o campo nome
+    const nomeInput = container.querySelector('[data-cy="perfil-nome"]') as HTMLInputElement;
+    fireEvent.input(nomeInput, { target: { value: '' } });
+
+    const form = container.querySelector('form') as HTMLFormElement;
+    fireEvent.submit(form);
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(screen.getByText('Nome é obrigatório.')).toBeTruthy();
+  });
+
+  it('deve exibir validacao de nome minimo ao submeter com nome curto', async () => {
+    const { container } = await setup();
+
+    httpTesting.expectOne('/api/v1/perfil').flush(perfilMock);
+    await new Promise(r => setTimeout(r, 0));
+
+    // Preencher nome com 1 caractere
+    const nomeInput = container.querySelector('[data-cy="perfil-nome"]') as HTMLInputElement;
+    fireEvent.input(nomeInput, { target: { value: 'A' } });
+
+    const form = container.querySelector('form') as HTMLFormElement;
+    fireEvent.submit(form);
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(screen.getByText('Nome deve ter pelo menos 2 caracteres.')).toBeTruthy();
+  });
+
+  it('deve exibir erro quando nova senha tem menos de 8 caracteres', async () => {
+    const { container } = await setup();
+
+    httpTesting.expectOne('/api/v1/perfil').flush(perfilMock);
+    await new Promise(r => setTimeout(r, 0));
+
+    // Preencher senha atual e nova senha curta
+    const senhaAtualInput = container.querySelector('[data-cy="perfil-senha-atual"] input') as HTMLInputElement;
+    const novaSenhaInput = container.querySelector('[data-cy="perfil-nova-senha"] input') as HTMLInputElement;
+    const confirmarInput = container.querySelector('[data-cy="perfil-confirmar-nova-senha"] input') as HTMLInputElement;
+    if (senhaAtualInput) {
+      fireEvent.input(senhaAtualInput, { target: { value: '12345678' } });
+    }
+    if (novaSenhaInput) {
+      fireEvent.input(novaSenhaInput, { target: { value: '1234' } });
+    }
+    if (confirmarInput) {
+      fireEvent.input(confirmarInput, { target: { value: '1234' } });
+    }
+
+    const form = container.querySelector('form') as HTMLFormElement;
+    fireEvent.submit(form);
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(screen.getByText('A nova senha deve ter pelo menos 8 caracteres.')).toBeTruthy();
+  });
 });

--- a/frontend/MapaTributario-ui/src/app/features/perfil/perfil.component.ts
+++ b/frontend/MapaTributario-ui/src/app/features/perfil/perfil.component.ts
@@ -1,0 +1,134 @@
+import { Component, inject, OnInit, signal } from '@angular/core';
+import { ReactiveFormsModule, FormBuilder, Validators, AbstractControl, ValidationErrors } from '@angular/forms';
+import { ButtonModule } from 'primeng/button';
+import { InputTextModule } from 'primeng/inputtext';
+import { PasswordModule } from 'primeng/password';
+import { MessageModule } from 'primeng/message';
+import { CardModule } from 'primeng/card';
+import { DividerModule } from 'primeng/divider';
+import { PerfilService } from './perfil.service';
+import { AuthService } from '../../core/auth/auth.service';
+
+function senhasConferemValidator(control: AbstractControl): ValidationErrors | null {
+  const novaSenha = control.get('novaSenha')?.value;
+  const confirmarNovaSenha = control.get('confirmarNovaSenha')?.value;
+  if (novaSenha && confirmarNovaSenha && novaSenha !== confirmarNovaSenha) {
+    return { senhasNaoConferem: true };
+  }
+  return null;
+}
+
+@Component({
+  selector: 'app-perfil',
+  standalone: true,
+  imports: [ReactiveFormsModule, ButtonModule, InputTextModule, PasswordModule, MessageModule, CardModule, DividerModule],
+  templateUrl: './perfil.component.html',
+  styleUrl: './perfil.component.scss',
+})
+export class PerfilComponent implements OnInit {
+  private readonly _fb = inject(FormBuilder);
+  private readonly _perfilService = inject(PerfilService);
+  private readonly _authService = inject(AuthService);
+
+  readonly carregando = signal(true);
+  readonly salvando = signal(false);
+  readonly mensagemErro = signal('');
+  readonly mensagemSucesso = signal('');
+
+  readonly form = this._fb.nonNullable.group(
+    {
+      nome: ['', [Validators.required, Validators.minLength(2)]],
+      email: [{ value: '', disabled: true }],
+      senhaAtual: [''],
+      novaSenha: [''],
+      confirmarNovaSenha: [''],
+    },
+    { validators: senhasConferemValidator },
+  );
+
+  ngOnInit(): void {
+    this._carregarPerfil();
+  }
+
+  onSubmit(): void {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      if (this.form.hasError('senhasNaoConferem')) {
+        this.mensagemErro.set('As senhas não coincidem.');
+        return;
+      }
+      return;
+    }
+
+    const { nome, senhaAtual, novaSenha, confirmarNovaSenha } = this.form.getRawValue();
+
+    if (novaSenha && !senhaAtual) {
+      this.mensagemErro.set('Informe a senha atual para alterar a senha.');
+      return;
+    }
+
+    if (senhaAtual && !novaSenha) {
+      this.mensagemErro.set('Informe a nova senha.');
+      return;
+    }
+
+    if (novaSenha && novaSenha.length < 8) {
+      this.mensagemErro.set('A nova senha deve ter pelo menos 8 caracteres.');
+      return;
+    }
+
+    if (novaSenha && novaSenha !== confirmarNovaSenha) {
+      this.mensagemErro.set('As senhas não coincidem.');
+      return;
+    }
+
+    this.salvando.set(true);
+    this.mensagemErro.set('');
+    this.mensagemSucesso.set('');
+
+    const dados = {
+      nome,
+      ...(senhaAtual && novaSenha ? { senhaAtual, novaSenha } : {}),
+    };
+
+    this._perfilService.atualizarPerfil(dados).subscribe({
+      next: (resposta) => {
+        this._authService.atualizarToken(resposta.accessToken);
+        this.form.patchValue({ senhaAtual: '', novaSenha: '', confirmarNovaSenha: '' });
+        this.mensagemSucesso.set('Perfil atualizado com sucesso!');
+        this.salvando.set(false);
+      },
+      error: (erro) => {
+        this.salvando.set(false);
+        if (erro.status === 400) {
+          const detalhes = erro.error?.detalhes ?? erro.error?.errors;
+          if (Array.isArray(detalhes) && detalhes.length > 0) {
+            this.mensagemErro.set(detalhes.join(', '));
+          } else if (erro.error?.erro) {
+            this.mensagemErro.set(erro.error.erro);
+          } else {
+            this.mensagemErro.set('Dados inválidos. Verifique os campos.');
+          }
+        } else if (erro.status === 401) {
+          this.mensagemErro.set('Sessão expirada. Faça login novamente.');
+        } else {
+          this.mensagemErro.set('Erro ao atualizar perfil. Tente novamente.');
+        }
+      },
+    });
+  }
+
+  private _carregarPerfil(): void {
+    this.carregando.set(true);
+    this._perfilService.obterPerfil().subscribe({
+      next: (perfil) => {
+        this.form.patchValue({ nome: perfil.nome, email: perfil.email });
+        this.carregando.set(false);
+      },
+      error: () => {
+        this.mensagemErro.set('Erro ao carregar perfil. Tente novamente.');
+        this.carregando.set(false);
+      },
+    });
+  }
+}

--- a/frontend/MapaTributario-ui/src/app/features/perfil/perfil.component.ts
+++ b/frontend/MapaTributario-ui/src/app/features/perfil/perfil.component.ts
@@ -38,7 +38,7 @@ export class PerfilComponent implements OnInit {
   readonly form = this._fb.nonNullable.group(
     {
       nome: ['', [Validators.required, Validators.minLength(2)]],
-      email: [{ value: '', disabled: true }],
+      email: [''],
       senhaAtual: [''],
       novaSenha: [''],
       confirmarNovaSenha: [''],

--- a/frontend/MapaTributario-ui/src/app/features/perfil/perfil.models.ts
+++ b/frontend/MapaTributario-ui/src/app/features/perfil/perfil.models.ts
@@ -1,0 +1,18 @@
+export interface PerfilResponse {
+  id: string;
+  nome: string;
+  email: string;
+}
+
+export interface AtualizarPerfilRequest {
+  nome: string;
+  senhaAtual?: string;
+  novaSenha?: string;
+}
+
+export interface AtualizarPerfilResponse {
+  id: string;
+  nome: string;
+  email: string;
+  accessToken: string;
+}

--- a/frontend/MapaTributario-ui/src/app/features/perfil/perfil.service.spec.ts
+++ b/frontend/MapaTributario-ui/src/app/features/perfil/perfil.service.spec.ts
@@ -1,0 +1,84 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { PerfilService } from './perfil.service';
+import { AtualizarPerfilRequest } from './perfil.models';
+
+describe('PerfilService', () => {
+  let service: PerfilService;
+  let httpTesting: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
+    service = TestBed.inject(PerfilService);
+    httpTesting = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpTesting.verify());
+
+  it('deve obter perfil do usuario', () => {
+    const perfilMock = { id: '123', nome: 'João', email: 'joao@test.com' };
+    service.obterPerfil().subscribe(perfil => {
+      expect(perfil).toEqual(perfilMock);
+    });
+    const req = httpTesting.expectOne('/api/v1/perfil');
+    expect(req.request.method).toBe('GET');
+    req.flush(perfilMock);
+  });
+
+  it('deve atualizar perfil apenas com nome', () => {
+    const dados: AtualizarPerfilRequest = { nome: 'João Atualizado' };
+    const respostaMock = { id: '123', nome: 'João Atualizado', email: 'joao@test.com', accessToken: 'novo-token' };
+
+    service.atualizarPerfil(dados).subscribe(resposta => {
+      expect(resposta).toEqual(respostaMock);
+    });
+
+    const req = httpTesting.expectOne('/api/v1/perfil');
+    expect(req.request.method).toBe('PUT');
+    expect(req.request.body).toEqual({ nome: 'João Atualizado' });
+    req.flush(respostaMock);
+  });
+
+  it('deve atualizar perfil com nome e senha', () => {
+    const dados: AtualizarPerfilRequest = { nome: 'João', senhaAtual: 'senha123', novaSenha: 'novaSenha123' };
+    const respostaMock = { id: '123', nome: 'João', email: 'joao@test.com', accessToken: 'novo-token' };
+
+    service.atualizarPerfil(dados).subscribe(resposta => {
+      expect(resposta).toEqual(respostaMock);
+    });
+
+    const req = httpTesting.expectOne('/api/v1/perfil');
+    expect(req.request.method).toBe('PUT');
+    expect(req.request.body).toEqual({ nome: 'João', senhaAtual: 'senha123', novaSenha: 'novaSenha123' });
+    req.flush(respostaMock);
+  });
+
+  it('deve propagar erro ao obter perfil', () => {
+    let statusErro = 0;
+    service.obterPerfil().subscribe({
+      error: (err) => { statusErro = err.status; },
+    });
+
+    httpTesting.expectOne('/api/v1/perfil').flush(
+      { erro: 'Não autorizado' },
+      { status: 401, statusText: 'Unauthorized' },
+    );
+    expect(statusErro).toBe(401);
+  });
+
+  it('deve propagar erro ao atualizar perfil', () => {
+    let statusErro = 0;
+    service.atualizarPerfil({ nome: 'João' }).subscribe({
+      error: (err) => { statusErro = err.status; },
+    });
+
+    httpTesting.expectOne('/api/v1/perfil').flush(
+      { erro: 'Senha incorreta' },
+      { status: 400, statusText: 'Bad Request' },
+    );
+    expect(statusErro).toBe(400);
+  });
+});

--- a/frontend/MapaTributario-ui/src/app/features/perfil/perfil.service.ts
+++ b/frontend/MapaTributario-ui/src/app/features/perfil/perfil.service.ts
@@ -1,0 +1,18 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+import { AtualizarPerfilRequest, AtualizarPerfilResponse, PerfilResponse } from './perfil.models';
+
+@Injectable({ providedIn: 'root' })
+export class PerfilService {
+  private readonly _http = inject(HttpClient);
+  private readonly _baseUrl = '/api/v1/perfil';
+
+  obterPerfil(): Observable<PerfilResponse> {
+    return this._http.get<PerfilResponse>(this._baseUrl);
+  }
+
+  atualizarPerfil(dados: AtualizarPerfilRequest): Observable<AtualizarPerfilResponse> {
+    return this._http.put<AtualizarPerfilResponse>(this._baseUrl, dados);
+  }
+}

--- a/frontend/MapaTributario-ui/src/app/layout/components/app-topbar.component.html
+++ b/frontend/MapaTributario-ui/src/app/layout/components/app-topbar.component.html
@@ -11,16 +11,27 @@
   <div class="layout-topbar-actions">
     <div class="layout-config-menu">
       @if (authService.userName()) {
-        <div class="layout-topbar-action flex items-center gap-2" data-cy="user-name">
+        <button type="button" class="layout-topbar-action flex items-center gap-2" data-cy="user-menu-trigger" (click)="toggleMenuUsuario($event)" aria-label="Menu do usuário">
           <i class="pi pi-user"></i>
-          <span class="text-surface-700 dark:text-surface-200 font-medium">{{ authService.userName() }}</span>
-        </div>
+          <span class="text-surface-700 dark:text-surface-200 font-medium" data-cy="user-name">{{ authService.userName() }}</span>
+          <i class="pi pi-chevron-down text-xs"></i>
+        </button>
+
+        <p-popover #menuUsuario data-cy="user-menu-popover">
+          <div class="flex flex-col gap-1 w-48">
+            <a routerLink="/perfil" class="flex items-center gap-2 p-3 rounded-lg hover:bg-surface-100 dark:hover:bg-surface-800 cursor-pointer no-underline text-surface-700 dark:text-surface-200" data-cy="menu-meu-perfil" (click)="fecharMenuUsuario()">
+              <i class="pi pi-user-edit"></i>
+              <span>Meu Perfil</span>
+            </a>
+            <button type="button" class="flex items-center gap-2 p-3 rounded-lg hover:bg-surface-100 dark:hover:bg-surface-800 cursor-pointer w-full border-none bg-transparent text-surface-700 dark:text-surface-200 text-left" data-cy="menu-sair" (click)="logout()">
+              <i class="pi pi-sign-out"></i>
+              <span>Sair</span>
+            </button>
+          </div>
+        </p-popover>
       }
       <button type="button" class="layout-topbar-action" (click)="toggleDarkMode()" [attr.aria-label]="layoutService.isDarkTheme() ? 'Ativar tema claro' : 'Ativar tema escuro'" [attr.aria-pressed]="layoutService.isDarkTheme()">
         <i [ngClass]="{ 'pi': true, 'pi-moon': layoutService.isDarkTheme(), 'pi-sun': !layoutService.isDarkTheme() }"></i>
-      </button>
-      <button type="button" class="layout-topbar-action" (click)="logout()" aria-label="Sair" data-cy="logout-button">
-        <i class="pi pi-sign-out"></i>
       </button>
     </div>
   </div>

--- a/frontend/MapaTributario-ui/src/app/layout/components/app-topbar.component.spec.ts
+++ b/frontend/MapaTributario-ui/src/app/layout/components/app-topbar.component.spec.ts
@@ -105,7 +105,7 @@ describe('AppTopbarComponent', () => {
 
     const { container, authService } = await setup();
     // Espionar logout sem executar a navegação para evitar problemas de teardown do Popover
-    const espiao = vi.spyOn(authService, 'logout').mockImplementation(() => {});
+    const espiao = vi.spyOn(authService, 'logout').mockImplementation(() => { /* noop para evitar teardown do Popover */ });
 
     // Abrir o menu do usuário
     const menuTrigger = container.querySelector('[data-cy="user-menu-trigger"]') as HTMLButtonElement;

--- a/frontend/MapaTributario-ui/src/app/layout/components/app-topbar.component.spec.ts
+++ b/frontend/MapaTributario-ui/src/app/layout/components/app-topbar.component.spec.ts
@@ -4,6 +4,7 @@ import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter, Router } from '@angular/router';
 import { TestBed } from '@angular/core/testing';
 import { PLATFORM_ID } from '@angular/core';
+import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import { AppTopbarComponent } from './app-topbar.component';
 import { LayoutService } from '../services/layout.service';
 import { AuthService } from '../../core/auth/auth.service';
@@ -14,6 +15,7 @@ describe('AppTopbarComponent', () => {
       providers: [
         provideHttpClient(),
         provideHttpClientTesting(),
+        provideAnimationsAsync(),
         provideRouter([
           { path: '', component: {} as any },
           { path: 'auth/login', component: {} as any },
@@ -94,14 +96,28 @@ describe('AppTopbarComponent', () => {
   });
 
   it('Given_CliqueBotaoLogout_Should_ChamarLogout', async () => {
-    // Arrange
+    // Arrange — simular token válido para que o menu do usuário apareça
+    const header = btoa(JSON.stringify({ alg: 'HS256' }));
+    const payload = btoa(JSON.stringify({ sub: '1', email: 'user@test.com', name: 'João Silva', exp: Math.floor(Date.now() / 1000) + 3600 }));
+    const token = `${header}.${payload}.sig`;
+    localStorage.setItem('rememberMe', 'true');
+    localStorage.setItem('accessToken', token);
+
     const { container, authService } = await setup();
-    const espiao = vi.spyOn(authService, 'logout');
-    const botaoLogout = container.querySelector('[data-cy="logout-button"]') as HTMLButtonElement;
-    expect(botaoLogout).toBeTruthy();
+    // Espionar logout sem executar a navegação para evitar problemas de teardown do Popover
+    const espiao = vi.spyOn(authService, 'logout').mockImplementation(() => {});
+
+    // Abrir o menu do usuário
+    const menuTrigger = container.querySelector('[data-cy="user-menu-trigger"]') as HTMLButtonElement;
+    expect(menuTrigger).toBeTruthy();
+    fireEvent.click(menuTrigger);
+
+    // Clicar no botão "Sair" dentro do popover
+    const botaoSair = document.querySelector('[data-cy="menu-sair"]') as HTMLButtonElement;
+    expect(botaoSair).toBeTruthy();
 
     // Act
-    fireEvent.click(botaoLogout);
+    fireEvent.click(botaoSair);
 
     // Assert
     expect(espiao).toHaveBeenCalledTimes(1);
@@ -151,5 +167,49 @@ describe('AppTopbarComponent', () => {
     // Assert
     expect(botaoDarkMode!.getAttribute('aria-label')).toBe('Ativar tema escuro');
     expect(botaoDarkMode!.getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('Given_UsuarioAutenticado_Should_ExibirBotaoMenuUsuario', async () => {
+    // Arrange
+    const header = btoa(JSON.stringify({ alg: 'HS256' }));
+    const payload = btoa(JSON.stringify({ sub: '1', email: 'user@test.com', name: 'João Silva', exp: Math.floor(Date.now() / 1000) + 3600 }));
+    const token = `${header}.${payload}.sig`;
+    localStorage.setItem('rememberMe', 'true');
+    localStorage.setItem('accessToken', token);
+
+    const { container } = await setup();
+
+    // Assert
+    const menuTrigger = container.querySelector('[data-cy="user-menu-trigger"]') as HTMLButtonElement;
+    expect(menuTrigger).toBeTruthy();
+    expect(menuTrigger.getAttribute('aria-label')).toBe('Menu do usuário');
+  });
+
+  it('Given_CliqueMenuUsuario_Should_ExibirLinkMeuPerfil', async () => {
+    // Arrange
+    const header = btoa(JSON.stringify({ alg: 'HS256' }));
+    const payload = btoa(JSON.stringify({ sub: '1', email: 'user@test.com', name: 'João Silva', exp: Math.floor(Date.now() / 1000) + 3600 }));
+    const token = `${header}.${payload}.sig`;
+    localStorage.setItem('rememberMe', 'true');
+    localStorage.setItem('accessToken', token);
+
+    const { container } = await setup();
+
+    // Abrir o menu
+    const menuTrigger = container.querySelector('[data-cy="user-menu-trigger"]') as HTMLButtonElement;
+    fireEvent.click(menuTrigger);
+
+    // Assert
+    const linkPerfil = document.querySelector('[data-cy="menu-meu-perfil"]') as HTMLAnchorElement;
+    expect(linkPerfil).toBeTruthy();
+    expect(linkPerfil.textContent).toContain('Meu Perfil');
+  });
+
+  it('Given_UsuarioNaoAutenticado_Should_NaoExibirBotaoMenuUsuario', async () => {
+    // Arrange — sem token
+    const { container } = await setup();
+
+    // Assert
+    expect(container.querySelector('[data-cy="user-menu-trigger"]')).toBeNull();
   });
 });

--- a/frontend/MapaTributario-ui/src/app/layout/components/app-topbar.component.ts
+++ b/frontend/MapaTributario-ui/src/app/layout/components/app-topbar.component.ts
@@ -2,14 +2,13 @@ import { Component, inject, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { Popover, PopoverModule } from 'primeng/popover';
-import { ButtonModule } from 'primeng/button';
 import { LayoutService } from '../services/layout.service';
 import { AuthService } from '../../core/auth/auth.service';
 
 @Component({
   selector: 'app-topbar',
   standalone: true,
-  imports: [CommonModule, RouterModule, PopoverModule, ButtonModule],
+  imports: [CommonModule, RouterModule, PopoverModule],
   templateUrl: './app-topbar.component.html',
   styleUrl: './app-topbar.component.scss',
 })

--- a/frontend/MapaTributario-ui/src/app/layout/components/app-topbar.component.ts
+++ b/frontend/MapaTributario-ui/src/app/layout/components/app-topbar.component.ts
@@ -1,13 +1,15 @@
-import { Component, inject } from '@angular/core';
+import { Component, inject, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
+import { Popover, PopoverModule } from 'primeng/popover';
+import { ButtonModule } from 'primeng/button';
 import { LayoutService } from '../services/layout.service';
 import { AuthService } from '../../core/auth/auth.service';
 
 @Component({
   selector: 'app-topbar',
   standalone: true,
-  imports: [CommonModule, RouterModule],
+  imports: [CommonModule, RouterModule, PopoverModule, ButtonModule],
   templateUrl: './app-topbar.component.html',
   styleUrl: './app-topbar.component.scss',
 })
@@ -15,11 +17,22 @@ export class AppTopbarComponent {
   layoutService = inject(LayoutService);
   authService = inject(AuthService);
 
+  @ViewChild('menuUsuario') menuUsuario!: Popover;
+
+  toggleMenuUsuario(evento: Event): void {
+    this.menuUsuario.toggle(evento);
+  }
+
+  fecharMenuUsuario(): void {
+    this.menuUsuario.hide();
+  }
+
   toggleDarkMode(): void {
     this.layoutService.toggleDarkMode();
   }
 
   logout(): void {
+    this.fecharMenuUsuario();
     this.authService.logout();
   }
 }

--- a/openspec/changes/perfil-usuario/.openspec.yaml
+++ b/openspec/changes/perfil-usuario/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-04

--- a/openspec/changes/perfil-usuario/design.md
+++ b/openspec/changes/perfil-usuario/design.md
@@ -1,0 +1,101 @@
+## Context
+
+O sistema MapaTributário possui autenticação JWT completa (registro, login, refresh token) mas não oferece funcionalidade de edição de perfil. A entidade `User` é imutável após criação (somente `Create`, `SetId`, `Deactivate`). O `IUserRepository` não possui método de atualização. A topbar exibe o nome do usuário e ícone de forma estática sem interação além do dark mode toggle.
+
+Componentes existentes relevantes:
+- `User.cs` — entidade de domínio com private setters
+- `IUserRepository` / `UserRepository` — somente `CreateAsync`, `GetByEmailAsync`, `GetByIdAsync`
+- `JwtTokenProvider` (implementa `ITokenProvider`) — já gera tokens com claims de nome, email, role
+- `AuthController` — endpoints públicos de login/register/refresh
+- `app-topbar.component` — layout estático com ícone de usuário
+- `AuthService` (frontend) — decode JWT, signals para nome/email/role
+
+## Goals / Non-Goals
+
+**Goals:**
+- Permitir que o usuário autenticado visualize e edite seu nome
+- Permitir alteração opcional de senha com verificação da senha atual
+- Fornecer dropdown interativo na topbar para acesso ao perfil
+- Atualizar a topbar imediatamente após mudança de nome (via novo JWT)
+- Manter consistência com os padrões existentes do projeto (controllers, DTOs, validadores)
+
+**Non-Goals:**
+- Edição de email (email é somente leitura)
+- Upload de avatar ou foto de perfil
+- Gestão de preferências ou configurações do usuário
+- Administração de perfis de outros usuários
+- Refresh token na resposta de atualização de perfil (somente accessToken)
+
+## Decisions
+
+### 1. Controller dedicado `PerfilController` vs endpoints no `AuthController`
+
+**Decisão**: Criar `PerfilController` separado.
+
+**Alternativa considerada**: Adicionar endpoints em `AuthController`. Rejeitada porque `AuthController` é público (sem `[Authorize]`), e os endpoints de perfil exigem autenticação. Separar mantém coesão — auth trata de autenticação, perfil trata de dados do usuário autenticado.
+
+### 2. Endpoint único `PUT /api/v1/perfil` vs endpoints separados para nome e senha
+
+**Decisão**: Endpoint único `PUT /api/v1/perfil` que trata nome e senha opcionalmente.
+
+**Alternativa considerada**: `PUT /api/v1/perfil/nome` e `PUT /api/v1/perfil/senha` separados. Rejeitada porque o cenário mais comum é atualizar tudo de uma vez num único formulário, e o custo de dois endpoints para uma feature simples não se justifica.
+
+**Contrato do request:**
+```json
+{
+  "nome": "string (obrigatório)",
+  "senhaAtual": "string (opcional — obrigatório somente se novaSenha preenchida)",
+  "novaSenha": "string (opcional — mínimo 8 caracteres se preenchida)"
+}
+```
+
+**Contrato do response (200):**
+```json
+{
+  "id": "string",
+  "nome": "string",
+  "email": "string",
+  "accessToken": "string"
+}
+```
+
+### 3. Emissão de novo JWT na resposta
+
+**Decisão**: O `PUT /api/v1/perfil` retorna um novo `accessToken` no corpo da resposta sempre que a atualização for bem-sucedida.
+
+**Justificativa**: O nome do usuário está na claim do JWT. Sem novo token, a topbar e outros pontos que leem o nome do token ficariam desatualizados até o próximo refresh. Retornar o token no corpo da resposta é mais simples que forçar um refresh flow.
+
+**Frontend**: Após receber a resposta, o `AuthService` atualiza o token no localStorage e re-decodifica as claims para atualizar os signals.
+
+### 4. Métodos de domínio na entidade `User`
+
+**Decisão**: Adicionar `AtualizarNome(string nome)` e `AtualizarSenha(string novoHash)` na entidade `User`.
+
+**Justificativa**: Mantém a lógica de domínio na entidade (DDD lite, consistente com `Deactivate()`). `AtualizarNome` valida nome não-vazio. `AtualizarSenha` recebe hash pronto (o hashing é responsabilidade da camada de aplicação/controller, como já feito no registro).
+
+### 5. OverlayPanel do PrimeNG para dropdown na topbar
+
+**Decisão**: Usar `OverlayPanel` do PrimeNG para o dropdown de usuário na topbar.
+
+**Alternativa considerada**: `Menu` ou `TieredMenu` do PrimeNG. Rejeitada porque OverlayPanel é mais flexível para layout customizado (pode conter qualquer template, não apenas itens de menu).
+
+**Interação**: Clicar no ícone/nome do usuário abre o OverlayPanel com dois itens: "Meu Perfil" (navegação via routerLink) e "Sair" (executa `logout()`).
+
+### 6. Verificação de senha no controller
+
+**Decisão**: A verificação de `senhaAtual` contra o hash armazenado é feita no controller/action, usando `BCrypt.Net.BCrypt.Verify()` diretamente (mesmo padrão usado no login pelo `AuthController`).
+
+**Justificativa**: Não há camada de application services no projeto — controllers fazem a orquestração diretamente. Manter consistência com o padrão existente.
+
+### 7. Identificação do usuário no endpoint
+
+**Decisão**: Extrair o ID do usuário autenticado via `User.FindFirst(ClaimTypes.NameIdentifier)` no controller (mesmo padrão do refresh token no `AuthController`).
+
+**Justificativa**: Não depende de dados no body, usa a claim do JWT — seguro e consistente.
+
+## Risks / Trade-offs
+
+- **[Risco] Token antigo no localStorage após atualização** → Mitigação: Frontend atualiza imediatamente o token no localStorage e re-decodifica claims após resposta 200 do PUT.
+- **[Risco] Concorrência na atualização** → Mitigação: Aceitável para POC. Última escrita vence. Não há cenário multi-sessão crítico.
+- **[Trade-off] Sem refresh token na resposta de perfil** → Simplifica o fluxo. O refresh token existente continua válido. Se expirar, o flow normal de refresh resolve.
+- **[Risco] OverlayPanel pode conflitar com o layout mobile** → Mitigação: Testar responsividade. OverlayPanel do PrimeNG já é responsivo por padrão.

--- a/openspec/changes/perfil-usuario/proposal.md
+++ b/openspec/changes/perfil-usuario/proposal.md
@@ -1,0 +1,45 @@
+## Why
+
+Atualmente o sistema não oferece nenhuma forma para o usuário autenticado visualizar ou editar seus dados de perfil (nome, senha). O ícone de usuário na topbar é estático e não oferece interação além do logout. Isso impede que usuários corrijam seu nome ou alterem sua senha sem intervenção direta no banco de dados.
+
+## What Changes
+
+- Adicionar menu dropdown (OverlayPanel) no ícone do usuário na topbar com opções "Meu Perfil" e "Sair"
+- Criar página de perfil (`/perfil`) com formulário para visualização e edição dos dados do usuário
+  - Nome: editável
+  - Email: somente leitura (exibido para informação)
+  - Alteração de senha: opcional — campos aparecem mas só são processados se preenchidos
+  - Exige senha atual para alterar a senha
+- Criar endpoints REST no backend para obter e atualizar perfil do usuário autenticado
+- Após atualização do nome, o backend emite novo JWT para que a topbar reflita a mudança imediatamente
+- Adicionar métodos de domínio na entidade `User` para atualização de nome e senha
+
+## Capabilities
+
+### New Capabilities
+- `perfil-usuario`: Capacidade de visualizar e editar perfil do usuário autenticado (nome e senha), incluindo endpoints backend, página frontend e interação via topbar
+
+### Modified Capabilities
+- `user-auth`: Adiciona requisito de emissão de novo JWT após atualização de nome, e adiciona métodos de mutação na entidade User (AtualizarNome, AtualizarSenha)
+- `frontend-foundation`: Adiciona requisito de interação no ícone do usuário na topbar (dropdown com navegação para perfil e logout)
+
+## Impact
+
+- **Backend**:
+  - `User.cs` — novos métodos de domínio (`AtualizarNome`, `AtualizarSenha`)
+  - `IUserRepository` / `UserRepository` — novo método `AtualizarAsync`
+  - Novo `PerfilController` com endpoints `GET /api/v1/perfil` e `PUT /api/v1/perfil`
+  - Novos DTOs: `PerfilResponse`, `AtualizarPerfilRequest`
+  - Novos validadores para os DTOs
+  - Reutiliza `JwtTokenGenerator` para emitir novo token após atualização
+- **Frontend**:
+  - `app-topbar.component` — adicionar OverlayPanel com dropdown de opções
+  - Novo `PerfilComponent` — página de edição de perfil
+  - Novo `PerfilService` — chamadas HTTP para os endpoints de perfil
+  - Nova rota `/perfil` em `app.routes.ts`
+- **Testes**:
+  - Testes unitários backend para novos métodos de domínio, controller, e validadores
+  - Testes unitários frontend para componentes e serviço
+  - Testes E2E Cypress para fluxo completo de edição de perfil
+- **Documentação**:
+  - `docs/api-contracts.md` — documentar novos endpoints de perfil

--- a/openspec/changes/perfil-usuario/specs/frontend-foundation/spec.md
+++ b/openspec/changes/perfil-usuario/specs/frontend-foundation/spec.md
@@ -1,0 +1,28 @@
+## MODIFIED Requirements
+
+### Requirement: Admin layout with sidebar navigation
+The frontend SHALL provide an authenticated admin layout with: topbar with logo and user actions, collapsible sidebar with menu items, main content area, and footer. The layout SHALL support static and overlay menu modes. The layout SHALL be responsive (desktop and mobile).
+
+#### Scenario: Desktop layout
+- **WHEN** a user accesses the application on a desktop screen (>1024px)
+- **THEN** the layout displays a static sidebar, topbar, and content area
+
+#### Scenario: Mobile layout
+- **WHEN** a user accesses the application on a mobile screen (<1024px)
+- **THEN** the sidebar becomes an overlay triggered by a hamburger button in the topbar
+
+#### Scenario: Menu navigation
+- **WHEN** a user clicks a menu item in the sidebar
+- **THEN** the application navigates to the corresponding route and highlights the active menu item
+
+#### Scenario: Dropdown do usuário na topbar
+- **WHEN** um usuário autenticado clica no ícone/nome do usuário na topbar
+- **THEN** um OverlayPanel/dropdown é exibido com as opções "Meu Perfil" (navega para `/perfil`) e "Sair" (executa logout)
+
+#### Scenario: Navegação para perfil via dropdown
+- **WHEN** o usuário clica em "Meu Perfil" no dropdown da topbar
+- **THEN** o sistema navega para a rota `/perfil` e o dropdown é fechado
+
+#### Scenario: Logout via dropdown
+- **WHEN** o usuário clica em "Sair" no dropdown da topbar
+- **THEN** o sistema executa o logout e redireciona para `/auth/login`

--- a/openspec/changes/perfil-usuario/specs/perfil-usuario/spec.md
+++ b/openspec/changes/perfil-usuario/specs/perfil-usuario/spec.md
@@ -1,0 +1,83 @@
+## ADDED Requirements
+
+### Requirement: Obter perfil do usuário autenticado
+O sistema SHALL expor `GET /api/v1/perfil` que retorna os dados do perfil do usuário autenticado. O endpoint SHALL exigir autenticação (qualquer role). Os dados retornados SHALL incluir: id, nome, email.
+
+#### Scenario: Obter perfil com sucesso
+- **WHEN** um usuário autenticado chama `GET /api/v1/perfil`
+- **THEN** o sistema retorna HTTP 200 com `{ id, nome, email }`
+
+#### Scenario: Usuário não autenticado tenta obter perfil
+- **WHEN** um usuário sem token válido chama `GET /api/v1/perfil`
+- **THEN** o sistema retorna HTTP 401 Unauthorized
+
+---
+
+### Requirement: Atualizar perfil do usuário autenticado
+O sistema SHALL expor `PUT /api/v1/perfil` que permite ao usuário autenticado atualizar seu nome e, opcionalmente, sua senha. O email NÃO SHALL ser editável. Se os campos de senha forem omitidos ou vazios, somente o nome SHALL ser atualizado. Se os campos de senha forem preenchidos, o sistema SHALL validar a senha atual antes de aceitar a nova senha.
+
+#### Scenario: Atualizar somente o nome
+- **WHEN** um usuário autenticado chama `PUT /api/v1/perfil` com `{ nome: "Novo Nome" }` sem campos de senha
+- **THEN** o sistema atualiza o nome, emite novo JWT com o nome atualizado, e retorna HTTP 200 com `{ id, nome, email, accessToken }`
+
+#### Scenario: Atualizar nome e senha
+- **WHEN** um usuário autenticado chama `PUT /api/v1/perfil` com `{ nome: "Novo Nome", senhaAtual: "12345678", novaSenha: "87654321" }`
+- **THEN** o sistema valida a senha atual, atualiza nome e hash da senha, emite novo JWT, e retorna HTTP 200 com `{ id, nome, email, accessToken }`
+
+#### Scenario: Senha atual incorreta
+- **WHEN** um usuário autenticado chama `PUT /api/v1/perfil` com senha atual incorreta
+- **THEN** o sistema retorna HTTP 400 Bad Request com `{ erro: "Senha atual incorreta" }`
+
+#### Scenario: Nova senha não atende requisitos mínimos
+- **WHEN** um usuário autenticado chama `PUT /api/v1/perfil` com nova senha com menos de 8 caracteres
+- **THEN** o sistema retorna HTTP 400 Bad Request com erro de validação
+
+#### Scenario: Nome vazio
+- **WHEN** um usuário autenticado chama `PUT /api/v1/perfil` com nome vazio ou em branco
+- **THEN** o sistema retorna HTTP 400 Bad Request com erro de validação
+
+#### Scenario: Nova senha preenchida sem senha atual
+- **WHEN** um usuário autenticado chama `PUT /api/v1/perfil` com `novaSenha` preenchida mas `senhaAtual` vazia
+- **THEN** o sistema retorna HTTP 400 Bad Request com `{ erro: "Senha atual é obrigatória para alterar a senha" }`
+
+---
+
+### Requirement: Página de perfil no frontend
+O frontend SHALL fornecer uma página em `/perfil` acessível a qualquer usuário autenticado. A página SHALL exibir um card único com: campo de nome (editável), campo de email (somente leitura), seção de alteração de senha (opcional). O formulário SHALL ter botão "Salvar" que envia as alterações.
+
+#### Scenario: Exibir dados do perfil
+- **WHEN** um usuário autenticado navega para `/perfil`
+- **THEN** a página carrega os dados do perfil via `GET /api/v1/perfil` e exibe nome (editável), email (somente leitura)
+
+#### Scenario: Editar somente o nome
+- **WHEN** o usuário altera o nome e clica "Salvar" sem preencher os campos de senha
+- **THEN** o sistema envia `PUT /api/v1/perfil` com apenas o nome, atualiza o token local, e a topbar reflete o novo nome
+
+#### Scenario: Editar nome e senha
+- **WHEN** o usuário altera o nome, preenche senha atual e nova senha, e clica "Salvar"
+- **THEN** o sistema envia `PUT /api/v1/perfil` com nome e senhas, atualiza o token local, e exibe mensagem de sucesso
+
+#### Scenario: Erro de validação no formulário
+- **WHEN** o usuário tenta salvar com nome vazio
+- **THEN** o formulário exibe erro inline no campo nome e não envia a requisição
+
+#### Scenario: Erro de senha atual incorreta
+- **WHEN** o backend retorna erro de senha atual incorreta
+- **THEN** o formulário exibe mensagem de erro no campo de senha atual
+
+#### Scenario: Rota protegida
+- **WHEN** um usuário não autenticado tenta acessar `/perfil`
+- **THEN** o frontend redireciona para `/auth/login`
+
+---
+
+### Requirement: Serviço de perfil no frontend
+O frontend SHALL fornecer um `PerfilService` que encapsula as chamadas HTTP para os endpoints de perfil (`GET /api/v1/perfil` e `PUT /api/v1/perfil`).
+
+#### Scenario: Obter perfil
+- **WHEN** o `PerfilService.obterPerfil()` é chamado
+- **THEN** ele faz `GET /api/v1/perfil` e retorna um Observable com os dados do perfil
+
+#### Scenario: Atualizar perfil
+- **WHEN** o `PerfilService.atualizarPerfil(dados)` é chamado
+- **THEN** ele faz `PUT /api/v1/perfil` com os dados e retorna um Observable com a resposta incluindo novo token

--- a/openspec/changes/perfil-usuario/specs/user-auth/spec.md
+++ b/openspec/changes/perfil-usuario/specs/user-auth/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: Métodos de mutação na entidade User
+A entidade `User` SHALL fornecer métodos de domínio para atualizar nome e senha. O método `AtualizarNome` SHALL validar que o nome não é vazio. O método `AtualizarSenha` SHALL receber o novo hash de senha.
+
+#### Scenario: Atualizar nome com valor válido
+- **WHEN** `AtualizarNome("Novo Nome")` é chamado em uma instância de User
+- **THEN** a propriedade `Nome` é atualizada para "Novo Nome"
+
+#### Scenario: Atualizar nome com valor vazio
+- **WHEN** `AtualizarNome("")` é chamado em uma instância de User
+- **THEN** o método lança exceção de validação
+
+#### Scenario: Atualizar senha
+- **WHEN** `AtualizarSenha(novoHash)` é chamado em uma instância de User
+- **THEN** a propriedade `PasswordHash` é atualizada para o novo hash
+
+---
+
+### Requirement: Persistência de atualização do usuário
+O repositório de usuários SHALL fornecer método `AtualizarAsync(User)` que persiste as alterações de uma entidade User existente no MongoDB.
+
+#### Scenario: Atualizar usuário existente
+- **WHEN** `AtualizarAsync(user)` é chamado com uma entidade User válida
+- **THEN** o documento correspondente no MongoDB é atualizado com os novos valores de Nome e PasswordHash
+
+---
+
+## MODIFIED Requirements
+
+### Requirement: Password security
+The system SHALL enforce minimum password requirements and store passwords securely.
+
+#### Scenario: Password hashing
+- **WHEN** a user registers or changes their password
+- **THEN** the system stores the password as a bcrypt hash with a cost factor of at least 12
+
+#### Scenario: Password minimum requirements
+- **WHEN** a user submits a password shorter than 8 characters
+- **THEN** the system rejects the request with HTTP 400
+
+#### Scenario: Validação de senha atual ao alterar senha
+- **WHEN** um usuário autenticado solicita alteração de senha via `PUT /api/v1/perfil`
+- **THEN** o sistema SHALL verificar a senha atual contra o hash armazenado antes de aceitar a nova senha
+
+#### Scenario: Emissão de novo JWT após atualização de perfil
+- **WHEN** o nome do usuário é atualizado com sucesso via `PUT /api/v1/perfil`
+- **THEN** o sistema SHALL emitir um novo JWT contendo o nome atualizado na claim `name`

--- a/openspec/changes/perfil-usuario/tasks.md
+++ b/openspec/changes/perfil-usuario/tasks.md
@@ -1,0 +1,47 @@
+## 1. Backend — Entidade e Repositório
+
+- [x] 1.1 Adicionar métodos `AtualizarNome(string nome)` e `AtualizarSenha(string novoHash)` na entidade `User.cs` com validação de nome não-vazio
+- [x] 1.2 Adicionar método `AtualizarAsync(User user)` na interface `IUserRepository` e implementar em `UserRepository` (update de Nome e PasswordHash no MongoDB)
+- [x] 1.3 Criar testes unitários para `AtualizarNome` e `AtualizarSenha` (cenários de sucesso e validação)
+- [x] 1.4 Criar teste de integração para `AtualizarAsync` no `UserRepository`
+
+## 2. Backend — DTOs e Validadores
+
+- [x] 2.1 Criar DTOs: `PerfilResponse` (id, nome, email) e `AtualizarPerfilRequest` (nome, senhaAtual?, novaSenha?)
+- [x] 2.2 Criar validador FluentValidation para `AtualizarPerfilRequest` (nome obrigatório, novaSenha mínimo 8 chars se preenchida, senhaAtual obrigatória se novaSenha preenchida)
+- [x] 2.3 Criar testes unitários para o validador
+
+## 3. Backend — Controller de Perfil
+
+- [x] 3.1 Criar `PerfilController` com `[Authorize]` e endpoints `GET /api/v1/perfil` e `PUT /api/v1/perfil`
+- [x] 3.2 Implementar `GET` — extrair userId do JWT, buscar usuário, retornar `PerfilResponse`
+- [x] 3.3 Implementar `PUT` — validar request, verificar senha atual se necessário (BCrypt.Verify), atualizar entidade, salvar, emitir novo JWT, retornar response com accessToken
+- [x] 3.4 Criar testes unitários para o `PerfilController` (obter perfil, atualizar nome, atualizar nome+senha, senha incorreta, validações)
+
+## 4. Frontend — Serviço de Perfil
+
+- [x] 4.1 Criar `PerfilService` com métodos `obterPerfil()` e `atualizarPerfil(dados)` usando HttpClient
+- [x] 4.2 Adicionar método no `AuthService` para atualizar token local e re-decodificar claims (`atualizarToken(novoToken)`)
+- [x] 4.3 Criar testes unitários para `PerfilService` e para o novo método do `AuthService`
+
+## 5. Frontend — Componente de Perfil
+
+- [x] 5.1 Criar `PerfilComponent` com formulário reativo: campo nome (editável), campo email (readonly), seção de senha opcional (senhaAtual, novaSenha)
+- [x] 5.2 Implementar lógica de submit: chamar `PerfilService.atualizarPerfil()`, atualizar token via `AuthService`, exibir toast de sucesso/erro
+- [x] 5.3 Adicionar rota `/perfil` em `app.routes.ts` protegida por AuthGuard
+- [x] 5.4 Criar testes unitários para `PerfilComponent` (renderização, validação, submit com sucesso, tratamento de erros)
+
+## 6. Frontend — Dropdown da Topbar
+
+- [x] 6.1 Modificar `app-topbar.component` para adicionar Popover do PrimeNG no ícone/nome do usuário
+- [x] 6.2 Implementar itens do dropdown: "Meu Perfil" (routerLink `/perfil`) e "Sair" (executa logout)
+- [x] 6.3 Criar testes unitários para o comportamento do dropdown na topbar
+
+## 7. Testes E2E
+
+- [x] 7.1 Criar spec Cypress para fluxo completo: login → dropdown topbar → navegar para perfil → editar nome → verificar topbar atualizada
+- [x] 7.2 Criar cenários E2E para alteração de senha (sucesso e senha incorreta)
+
+## 8. Documentação
+
+- [x] 8.1 Atualizar `docs/api-contracts.md` com os novos endpoints `GET /api/v1/perfil` e `PUT /api/v1/perfil`


### PR DESCRIPTION
## Summary

Implementa a feature **Perfil de Usuário** que permite ao usuário autenticado visualizar e editar seu perfil (nome e senha) através de um dropdown na topbar e uma página dedicada `/perfil`.

## Alterações

### Backend
- **Entidade `User`**: novos métodos `AtualizarNome()` e `AtualizarSenha()`
- **Repositório**: `AtualizarAsync(User)` no `IUserRepository` / `UserRepository`
- **DTOs**: `PerfilResponse`, `AtualizarPerfilRequest`, `AtualizarPerfilResponse`
- **Validador**: `AtualizarPerfilRequestValidator` com FluentValidation
- **Controller**: `PerfilController` com `[Authorize]`
  - `GET /api/v1/perfil` — retorna dados do perfil
  - `PUT /api/v1/perfil` — atualiza nome e/ou senha, re-emite JWT

### Frontend
- **PerfilService**: `obterPerfil()` e `atualizarPerfil()`
- **AuthService**: novo método `atualizarToken()` para atualizar JWT local
- **PerfilComponent**: formulário reativo com nome (editável), email (readonly), seção de alteração de senha opcional com confirmação e validação cross-field
- **Rota** `/perfil` protegida por `authGuard`
- **Topbar**: Popover PrimeNG com dropdown contendo "Meu Perfil" e "Sair" (substituiu botão standalone de logout)

### Testes
- **Backend unitários**: 20+ testes (User, Validador, Controller)
- **Backend integração**: 7 testes com Testcontainers MongoDB
- **Frontend unitários**: 17+ testes (PerfilService, AuthService, PerfilComponent, Topbar)
- **Cypress E2E**: 10 cenários (navegação via dropdown, edição de nome, alteração de senha, senhas não coincidem, rota protegida)

### Documentação
- `docs/api-contracts.md` atualizado com os novos endpoints
- Artefatos OpenSpec completos (proposal, design, specs, tasks)

## Issues
Closes #46, closes #47, closes #48, closes #49, closes #50, closes #51, closes #52, closes #53